### PR TITLE
Fix #27 Help toggling also triggering back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_deploy:
 - export BODY=$(git log -1  --pretty='%s')
 
 deploy:
+  skip_cleanup: true
   provider: releases
   api_key:
     secure: cQ6o4ThE2IEfMjhKYch1bnOtTPO3GAmEdLfhrJebYiLRXiL4o/etOvHC89CSvrgbokShC57UL7h+IDD9JnRyk5H6hcNi3sLmYe5uCg205GjYcuxwCxAp9iuUOnwiiH0R7FegXj1+YUb/ockSO9cMispObC+SHrnq802BeRPyXrVQ3ECwXuQLbJp/0Ib9ouBhAVo2vti6RjFqOLcUpBYfN4uIbZDoxjIyXDvtuP2/LXnZ5WZw4COTM8ut2Kc1HKr1Ci97PxWPahXKW+9eyD30IXs2qmjd/gEamftXifXbAsaZlC9Gex4YpvXMGPytJm5TCH2MTZLAKwGKelwWLIj8FwlBt6YZbIcuLfIK1PZQBdohW8UXdddh//eplDNtn9NBqEk+qww0R7SUIvvND0NFokesTs/vBQ17JJXCRbzhl9gLMYvaifYIUCP7UyXZdpmHAKHlLmbkqBCcLspoppFNoneG/vx3jbb2ptubdYqmb5pR9W/FKxQBsSVqNcH8S2+yFcSnTjK/idJ7gnLNsddqdTdbBfIsmpOdHJR03Ka5qQ/c0P1v6qkiO/VxAdcFHiybyNaQ/y8cEJ4MX+x82ZHAd/tyZIwuxch/VCDSHrt2KTMtVMq3O5Tk2v8oDEzeYudJYUMsqCZmyzNrEu3aGO2N16EnzRt66Me5SDfExCWX8Kw=

--- a/help.go
+++ b/help.go
@@ -25,10 +25,10 @@ func DrawHelp(v *gocui.View) {
                         Interactive CLI for browsing Azure resources                                                                                                                                                                     
 # Navigation                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                 
-| Key         | Does                 |
-| ----------- | -------------------- |
-| ⇧ / ⇩       | Select resource      |
-| ⇦ / ⇨       | Select Menu/JSON     |               
+| Key         | Does                 |                                                                                                                                                                                                                                              
+| ----------- | -------------------- |                                                                                                                                                                                                                                              
+| ⇧ / ⇩       | Select resource      |                                                                                                                                                                                                                                              
+| ⇦ / ⇨       | Select Menu/JSON     |                                                                                                                                                                                                                                                             
 | Backspace   | Go back              |                                                                                                                                                                                                           
 | ENTER       | Expand/View resource |                                                                                                                                                                                                           
 | F5          | Refresh              |                                                                                                                                                                                                           

--- a/help.go
+++ b/help.go
@@ -17,7 +17,7 @@ func ToggleHelpView(g *gocui.Gui) {
 func DrawHelp(v *gocui.View) {
 
 	fmt.Fprint(v, style.Header(`
-	--> PRESS CTRL+H TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+H AT ANY TIME. <--                                                                                                                                  
+	--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--                                                                                                                                  
                              _       ___                                                                                                                                                                                                 
                             /_\   __| _ )_ _ _____ __ _____ ___                                                                                                                                                                          
                            / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)                                                                                                                                                                         
@@ -46,7 +46,7 @@ func DrawHelp(v *gocui.View) {
                                                                                                                                                                                                            
 For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse                                                                        
                                                                                                                                                                                                                                                                                                                                                             
---> PRESS CTRL+H TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+H AT ANY TIME. <--                                                                                                                                                                                                            
+--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--                                                                                                                                                                                                            
 `))
 
 }

--- a/help.go
+++ b/help.go
@@ -7,30 +7,9 @@ import (
 	"github.com/lawrencegripper/azbrowse/style"
 )
 
-var showHelp bool
-
 // ToggleHelpView shows and hides the help view
 func ToggleHelpView(g *gocui.Gui) {
-	showHelp = !showHelp
 
-	// If we're up and running clear and redraw the view
-	// if w.g != nil {
-	if showHelp {
-		g.Update(func(g *gocui.Gui) error {
-			maxX, maxY := g.Size()
-			// Padding
-			maxX = maxX - 2
-			maxY = maxY - 2
-			v, err := g.SetView("helpWidget", 1, 1, 140, 32)
-			if err != nil && err != gocui.ErrUnknownView {
-				panic(err)
-			}
-			DrawHelp(v)
-			return nil
-		})
-	} else {
-		g.DeleteView("helpWidget")
-	}
 	// }
 }
 
@@ -46,13 +25,13 @@ func DrawHelp(v *gocui.View) {
                         Interactive CLI for browsing Azure resources                                                                                                                                                                     
 # Navigation                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                 
-| Key       | Does                 |                                                                                                                                                                                                                                                 
-| --------- | -------------------- |                                                                                                                                                                                                            
-| ↑/↓       | Select resource      |                                                                                                                                                                                                           
-| Backspace | Go back              |                                                                                                                                                                                                           
-| ENTER     | Expand/View resource |                                                                                                                                                                                                           
-| F5        | Refresh              |                                                                                                                                                                                                           
-| CTRL+H    | Show this page       |                                                                                                                                                                                                           
+| Key         | Does                 |                                                                                                                                                                                                                                                 
+| ----------- | -------------------- |                                                                                                                                                                                                            
+| ↑/↓         | Select resource      |                                                                                                                                                                                                           
+| Backspace/← | Go back              |                                                                                                                                                                                                           
+| ENTER/→     | Expand/View resource |                                                                                                                                                                                                           
+| F5          | Refresh              |                                                                                                                                                                                                           
+| CTRL+H      | Show this page       |                                                                                                                                                                                                           
                                                                                                                                                                                                            
 # Operations	                                                                                                                                                                                                           
                                                                                                                                                                                                            

--- a/main.go
+++ b/main.go
@@ -153,13 +153,6 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.SetKeybinding("listWidget", gocui.KeyArrowRight, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
-		list.ExpandCurrentSelection()
-		return nil
-	}); err != nil {
-		log.Panicln(err)
-	}
-
 	if err := g.SetKeybinding("listWidget", gocui.KeyF5, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.GoBack()
 		list.ExpandCurrentSelection()
@@ -168,6 +161,7 @@ func main() {
 		log.Panicln(err)
 	}
 
+	// Handle backspace for modern terminals
 	if err := g.SetKeybinding("listWidget", gocui.KeyBackspace2, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.GoBack()
 		return nil
@@ -175,7 +169,10 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.SetKeybinding("listWidget", gocui.KeyArrowLeft, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+	// Handle backspace for out-dated terminals
+	// A side-effect is that this key combination clashes with CTRL+H so we can't use that combination for help... oh well.
+	// https://superuser.com/questions/375864/ctrlh-causing-backspace-instead-of-help-in-emacs-on-cygwin
+	if err := g.SetKeybinding("listWidget", gocui.KeyBackspace, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.GoBack()
 		return nil
 	}); err != nil {
@@ -250,7 +247,7 @@ func main() {
 	}
 
 	var showHelp bool
-	if err := g.SetKeybinding("", gocui.KeyCtrlH, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+	if err := g.SetKeybinding("", gocui.KeyCtrlI, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		showHelp = !showHelp
 
 		// If we're up and running clear and redraw the view

--- a/main.go
+++ b/main.go
@@ -132,13 +132,6 @@ func main() {
 	g.SetManager(status, content, list)
 	g.SetCurrentView("listWidget")
 
-	if err := g.SetKeybinding("", gocui.KeyCtrlH, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
-		list.ChangeSelection(list.CurrentSelection() + 1)
-		return nil
-	}); err != nil {
-		log.Panicln(err)
-	}
-
 	if err := g.SetKeybinding("listWidget", gocui.KeyArrowDown, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.ChangeSelection(list.CurrentSelection() + 1)
 		return nil
@@ -160,6 +153,13 @@ func main() {
 		log.Panicln(err)
 	}
 
+	if err := g.SetKeybinding("listWidget", gocui.KeyArrowRight, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		list.ExpandCurrentSelection()
+		return nil
+	}); err != nil {
+		log.Panicln(err)
+	}
+
 	if err := g.SetKeybinding("listWidget", gocui.KeyF5, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.GoBack()
 		list.ExpandCurrentSelection()
@@ -175,7 +175,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.SetKeybinding("listWidget", gocui.KeyBackspace, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+	if err := g.SetKeybinding("listWidget", gocui.KeyArrowLeft, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.GoBack()
 		return nil
 	}); err != nil {
@@ -249,8 +249,21 @@ func main() {
 		log.Panicln(err)
 	}
 
+	var showHelp bool
 	if err := g.SetKeybinding("", gocui.KeyCtrlH, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
-		ToggleHelpView(g)
+		showHelp = !showHelp
+
+		// If we're up and running clear and redraw the view
+		// if w.g != nil {
+		if showHelp {
+			v, err := g.SetView("helppopup", 1, 1, 140, 32)
+			if err != nil && err != gocui.ErrUnknownView {
+				panic(err)
+			}
+			DrawHelp(v)
+		} else {
+			g.DeleteView("helppopup")
+		}
 		return nil
 	}); err != nil {
 		log.Panicln(err)

--- a/statusbar.go
+++ b/statusbar.go
@@ -46,7 +46,7 @@ func (w *StatusbarWidget) Layout(g *gocui.Gui) error {
 		return err
 	}
 	v.Clear()
-	v.Title = `Status (CTRL+H for Help)`
+	v.Title = `Status (CTRL+I for Help)`
 	v.Wrap = true
 
 	if w.loading {

--- a/statusbar.go
+++ b/statusbar.go
@@ -46,7 +46,7 @@ func (w *StatusbarWidget) Layout(g *gocui.Gui) error {
 		return err
 	}
 	v.Clear()
-	v.Title = `Status (CTRL+I for Help)`
+	v.Title = `Status [CTRL+I -> Help]`
 	v.Wrap = true
 
 	if w.loading {

--- a/treeview.go
+++ b/treeview.go
@@ -246,13 +246,16 @@ func (w *ListWidget) ExpandCurrentSelection() {
 
 	if currentItem.expandReturnType == "none" {
 		w.title = w.title + ">" + currentItem.name
+		w.contentView.SetContent(data, "[CTRL+F -> Fullscreen|CTRL+A -> Actions] "+currentItem.name)
+		w.view.Title = w.title
+	} else {
+		w.contentView.SetContent(data, "[CTRL+F -> Fullscreen] "+currentItem.name)
 	}
+
 	if err == nil {
 		w.statusView.Status("Fetching item completed:"+currentItem.expandURL, false)
 	}
 
-	w.contentView.SetContent(data, currentItem.name)
-	w.view.Title = w.title
 }
 
 // ChangeSelection updates the selected item


### PR DESCRIPTION
This was a super weird one. 

1. I had two "ctrl+H" registered (copy and paste error). 
2. "keyBackspace" and "keyCtrlH" did the same thing (I've removed keybackspace and now just use keybackspace2)

While I was messing around right and left arrows now go back and forward in the navigation stack too

