### PR TITLE
Allow use of Left/Right keys to switch between list and JSON 

### DIFF
--- a/help.go
+++ b/help.go
@@ -38,36 +38,37 @@ func ToggleHelpView(g *gocui.Gui) {
 func DrawHelp(v *gocui.View) {
 
 	fmt.Fprint(v, style.Header(`
-	--> PRESS CTRL+H TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+H AT ANY TIME. <--                                                                                                                                  
-                             _       ___                                                                                                                                                                                                 
-                            /_\   __| _ )_ _ _____ __ _____ ___                                                                                                                                                                          
-                           / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)                                                                                                                                                                         
-                          /_/ \_\/__|___/_| \___/\_/\_//__/\___|                                                                                                                                                                         
-                        Interactive CLI for browsing Azure resources                                                                                                                                                                     
-# Navigation                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                                
-| Key       | Does                 |                                                                                                                                                                                                                                                 
-| --------- | -------------------- |                                                                                                                                                                                                            
-| ↑/↓       | Select resource      |                                                                                                                                                                                                           
-| Backspace | Go back              |                                                                                                                                                                                                           
-| ENTER     | Expand/View resource |                                                                                                                                                                                                           
-| F5        | Refresh              |                                                                                                                                                                                                           
-| CTRL+H    | Show this page       |                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-# Operations	                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-| Key                 | Does                      |                                                                                    |                                                                                                                                                                                                           
-| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- |                                                                                                                                                                                                           
-| CTRL+E              | Toggle Browse JSON        | For longer responses you can move the cursor to scroll the doc                     |                                                                                                                                                                                                           
-| CTLT+F              | Toggle Fullscreen         | Gives a fullscreen view of the JSON for smaller terminals                          |                                                                                                                                                                                                           
-| CTRL+O (o for open) | Open Portal               | Opens the portal at the currently selected resource                                |                                                                                                                                                                                                           
-| DEL                 | Delete resource           | The currently selected resource will be deleted (Requires double press to confirm) |                                                                                                                                                                                                           
-| CTLT+S              | Save JSON to clipboard    | Saves the last JSON response to the clipboard for export                           |                                                                                                                                                                                                           
-| CTLT+A              | View Actions for resource | This allows things like ListKeys on storage or Restart on VMs                      |                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse                                                                        
-                                                                                                                                                                                                                                                                                                                                                            
---> PRESS CTRL+H TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+H AT ANY TIME. <--                                                                                                                                                                                                            
+	--> PRESS CTRL+H TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+H AT ANY TIME. <--
+                             _       ___
+                            /_\   __| _ )_ _ _____ __ _____ ___
+                           / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)
+                          /_/ \_\/__|___/_| \___/\_/\_//__/\___|
+                        Interactive CLI for browsing Azure resources
+# Navigation
+
+| Key       | Does                 |
+| --------- | -------------------- |
+| ⇧ / ⇩     | Select resource      |
+| ⇦ / ⇨     | Select Menu/JSON     |
+| Backspace | Go back              |
+| ENTER     | Expand/View resource |
+| F5        | Refresh              |
+| CTRL+H    | Show this page       |
+
+# Operations
+
+| Key                 | Does                      |                                                                                    |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- |
+| CTRL+E              | Toggle Browse JSON        | For longer responses you can move the cursor to scroll the doc                     |
+| CTLT+F              | Toggle Fullscreen         | Gives a fullscreen view of the JSON for smaller terminals                          |
+| CTRL+O (o for open) | Open Portal               | Opens the portal at the currently selected resource                                |
+| DEL                 | Delete resource           | The currently selected resource will be deleted (Requires double press to confirm) |
+| CTLT+S              | Save JSON to clipboard    | Saves the last JSON response to the clipboard for export                           |
+| CTLT+A              | View Actions for resource | This allows things like ListKeys on storage or Restart on VMs                      |
+
+For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse
+
+--> PRESS CTRL+H TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+H AT ANY TIME. <--
 `))
 
 }

--- a/itemview.go
+++ b/itemview.go
@@ -23,16 +23,13 @@ func NewItemWidget(x, y, w, h int, content string) *ItemWidget {
 func (w *ItemWidget) Layout(g *gocui.Gui) error {
 	w.g = g
 	v, err := g.SetView("itemWidget", w.x, w.y, w.x+w.w, w.y+w.h)
-	// if err != nil {
-	// 	panic(err)
-	// }
+	if err != nil && err != gocui.ErrUnknownView {
+		return err
+	}
 	v.Editable = true
 	v.Wrap = true
 
 	w.view = v
-	if err != nil && err != gocui.ErrUnknownView {
-		return err
-	}
 	v.Clear()
 
 	fmt.Fprint(v, w.content)

--- a/main.go
+++ b/main.go
@@ -218,6 +218,24 @@ func main() {
 		log.Panicln(err)
 	}
 
+	if err := g.SetKeybinding("listWidget", gocui.KeyArrowRight, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		editModelEnabled = true
+		g.Cursor = true
+		g.SetCurrentView("itemWidget")
+		return nil
+	}); err != nil {
+		log.Panicln(err)
+	}
+
+	if err := g.SetKeybinding("itemWidget", gocui.KeyArrowLeft, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		editModelEnabled = false
+		g.Cursor = false
+		g.SetCurrentView("listWidget")
+		return nil
+	}); err != nil {
+		log.Panicln(err)
+	}
+
 	isFullScreen := false
 	if err := g.SetKeybinding("", gocui.KeyCtrlF, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		isFullScreen = !isFullScreen

--- a/main.go
+++ b/main.go
@@ -175,6 +175,17 @@ func main() {
 		log.Panicln(err)
 	}
 
+	// When back is pressed in the itemWidget go back and also move
+	// focus to the list of resources
+	if err := g.SetKeybinding("itemWidget", gocui.KeyBackspace2, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		g.SetCurrentView("listWidget")
+		g.Cursor = false
+		list.GoBack()
+		return nil
+	}); err != nil {
+		log.Panicln(err)
+	}
+
 	if err := g.SetKeybinding("listWidget", gocui.KeyBackspace, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
 		list.GoBack()
 		return nil


### PR DESCRIPTION
This PR allows the user to switch between the list and the JSON views using left/right keys. It also preserves the CTRL-E toggle, but that could easily be removed if this was felt to be redundant.

In addition to updating the Help with appropriate text, I've taken the liberty of using slightly different unicode arrows, which I felt were slightly easier to read. Happy to be told otherwise.