### PR TITLE
Updates to handler refactoring

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/lawrencegripper/azbrowse/tracing"
 	"strings"
 	"time"
+
+	"github.com/lawrencegripper/azbrowse/tracing"
 
 	"github.com/jroimartin/gocui"
 	"github.com/lawrencegripper/azbrowse/armclient"
@@ -167,9 +168,10 @@ func (w *ListWidget) ExpandCurrentSelection() {
 			continue
 		}
 
-		// Fire each handler in parellel
+		// Fire each handler in parallel
+		hCurrent := h // capture current iteration variable
 		go func() {
-			completedExpands <- h.Expand(ctx, currentItem)
+			completedExpands <- hCurrent.Expand(ctx, currentItem)
 		}()
 
 		handlerExpanding = handlerExpanding + 1

--- a/treeview.go
+++ b/treeview.go
@@ -178,8 +178,13 @@ func (w *ListWidget) ExpandCurrentSelection() {
 	}
 	spanQuery.Finish()
 
-	// Lets give all the expanders 45secs to completed
-	timeout := time.After(time.Second * 45)
+	// Lets give all the expanders 45secs to completed (unless debugging)
+	var timeout <-chan time.Time
+	if enableTracing {
+		timeout = time.After(time.Second * 600)
+	} else {
+		timeout = time.After(time.Second * 45)
+	}
 	for index := 0; index < handlerExpanding; index++ {
 		select {
 		case done := <-completedExpands:


### PR DESCRIPTION
Fix uncaptured loop variable that caused the last defined handler to always be used
Extend handler timeout to 10 mins when `debug` flag is specified
