### PR TITLE
Fix actions in the new handler model

### DIFF
--- a/handlers/resourcegroup.go
+++ b/handlers/resourcegroup.go
@@ -88,5 +88,6 @@ func (e *ResourceGroupResourceExpander) Expand(ctx context.Context, currentItem 
 		Nodes:             &newItems,
 		Response:          string(data),
 		SourceDescription: "Resources Request",
+		IsPrimaryResponse: true,
 	}
 }

--- a/handlers/subscription.go
+++ b/handlers/subscription.go
@@ -65,5 +65,6 @@ func (e *SubscriptionExpander) Expand(ctx context.Context, currentItem TreeNode)
 		Nodes:             &newItems,
 		Response:          string(data),
 		SourceDescription: "Resource Group Request",
+		IsPrimaryResponse: true,
 	}
 }

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -21,6 +21,9 @@ type ExpanderResult struct {
 	Nodes             *[]TreeNode
 	Err               error
 	SourceDescription string
+	// When set to true this causes the response
+	// in the result to be displayed in the content panel
+	IsPrimaryResponse bool
 }
 
 // Register tracks all the current handlers


### PR DESCRIPTION
Closes #37 

This also optimizes the handler allowing `IsPrimaryResponse` to be set on a result to indicate that this is the content to be shown to the user, this minimizes duplicate calls to resources for some handlers. 

If no primary response is set the generic handler calls the resources id. 