### PR TITLE
Add partial implementation of AppServiceExpander

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,15 +17,6 @@
             "args": [],
             // run azbrowse in a terminal with the following command before starting the debugger
             // go build &&  dlv exec ./azbrowse --headless --listen localhost:2345 --api-version 2
-        },
-        {
-            "name": "Launch",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${fileDirname}",
-            "env": {},
-            "args": []
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,20 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Connect to server",
+            "type": "go",
+            "request": "launch",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [],
+            // run azbrowse in a terminal with the following command before starting the debugger
+            // go build &&  dlv exec ./azbrowse --headless --listen localhost:2345 --api-version 2
+        },
+        {
             "name": "Launch",
             "type": "go",
             "request": "launch",

--- a/endpoints/endpointinfo.go
+++ b/endpoints/endpointinfo.go
@@ -13,9 +13,12 @@ type EndpointInfo struct {
 	Verb        string
 }
 
+// EndpointSegment reprsesents a segment of a template URL
 type EndpointSegment struct {
+	// holds a literal to match for fixed segments (e.g. /subscriptions/)
 	Match string
-	Name  string
+	// holds the name of a templated segment (e.g. 'name' for /{name}/)
+	Name string
 }
 
 // MatchResult holds information about an EndPointInfo match

--- a/endpoints/endpointinfo.go
+++ b/endpoints/endpointinfo.go
@@ -1,0 +1,117 @@
+package endpoints
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EndpointInfo represents an ARM endpoint
+type EndpointInfo struct {
+	TemplateURL string
+	APIVersion  string
+	URLSegments []EndpointSegment
+	Verb        string
+}
+
+type EndpointSegment struct {
+	Match string
+	Name  string
+}
+
+// MatchResult holds information about an EndPointInfo match
+type MatchResult struct {
+	// indicates whether this was a match
+	IsMatch bool
+	// holds the values pulled from named segments of the URL
+	Values map[string]string
+}
+
+// GetEndpointInfoFromURL builds an EndpointInfo instance
+func GetEndpointInfoFromURL(templateURL string, apiVersion string) (EndpointInfo, error) {
+	// This is currently generating at runtime, but would be a build-time task that generated code :-)
+	originalTemplateURL := templateURL
+	templateURL = strings.TrimPrefix(templateURL, "/")
+	templateURLSegments := strings.Split(templateURL, "/")
+	urlSegments := make([]EndpointSegment, len(templateURLSegments))
+	for i, s := range templateURLSegments {
+		if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+			name := strings.TrimPrefix(strings.TrimSuffix(s, "}"), "{")
+			if name == "" {
+				return EndpointInfo{}, fmt.Errorf("Segment index %d is a named segment but is missing the name", i)
+			}
+			urlSegments[i] = EndpointSegment{
+				Name: name,
+			}
+		} else {
+			urlSegments[i] = EndpointSegment{
+				Match: s,
+			}
+		}
+	}
+
+	return EndpointInfo{
+		TemplateURL: originalTemplateURL,
+		APIVersion:  apiVersion,
+		URLSegments: urlSegments,
+	}, nil
+}
+
+// Match tests whether a URL matches the EndpointInfo (ignoring query string values)
+func (ei *EndpointInfo) Match(url string) MatchResult {
+
+	url = strings.TrimPrefix(url, "/")
+
+	// strip off querystring for matching
+	if i := strings.Index(url, "?"); i >= 0 {
+		url = url[:i]
+	}
+
+	urlSegments := strings.Split(url, "/")
+	if len(urlSegments) == len(ei.URLSegments) {
+		isMatch := true
+		matches := make(map[string]string)
+		for i, segment := range ei.URLSegments {
+			if segment.Name == "" {
+				// literal match
+				if segment.Match != urlSegments[i] {
+					isMatch = false
+					break
+				}
+			} else {
+				// capture name
+				matches[segment.Name] = urlSegments[i]
+			}
+		}
+		if isMatch {
+			return MatchResult{
+				IsMatch: true,
+				Values:  matches,
+			}
+		}
+	}
+
+	return MatchResult{
+		IsMatch: false,
+	}
+}
+
+// BuildURL generates a URL based on the templateURL filling in placeholders with the values map
+func (ei *EndpointInfo) BuildURL(values map[string]string) (string, error) {
+
+	url := ""
+	for _, segment := range ei.URLSegments {
+		if segment.Match == "" {
+			value := values[segment.Name]
+			if value == "" {
+				return "", fmt.Errorf("No value was found with name1 '%s'", segment.Match)
+			}
+			url += "/" + value
+		} else {
+			url += "/" + segment.Match
+		}
+	}
+	if ei.APIVersion != "" {
+		url += "?api-version=" + ei.APIVersion
+	}
+	return url, nil
+}

--- a/endpoints/endpointinfo_test.go
+++ b/endpoints/endpointinfo_test.go
@@ -1,0 +1,149 @@
+package endpoints
+
+import "testing"
+
+func TestNonMatchOnFixedString(t *testing.T) {
+
+	// shouldn't match because "Microsoft.Web" != "Random"
+	matchResult := getMatchResult(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config",
+		"/subscriptions/random/resourceGroups/aaaaa/providers/Random/sites/azbrowsetest/config")
+
+	if matchResult.IsMatch {
+		t.Error("Shouldn't match")
+	}
+}
+func TestNonMatchOnMissingSegment(t *testing.T) {
+
+	// Shouldn't match because url is missing final "config" segment
+	matchResult := getMatchResult(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config",
+		"/subscriptions/random/resourceGroups/aaaaa/providers/Random/sites/azbrowsetest")
+
+	if matchResult.IsMatch {
+		t.Error("Shouldn't match")
+	}
+}
+func TestNonMatchOnExtraSegment(t *testing.T) {
+
+	//shouldn't match because url has extra "config" segment
+	matchResult := getMatchResult(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}",
+		"/subscriptions/random/resourceGroups/aaaaa/providers/Random/sites/azbrowsetest/config")
+
+	if matchResult.IsMatch {
+		t.Error("Shouldn't match")
+	}
+}
+
+func TestMatch(t *testing.T) {
+
+	//shouldn't match because url has extra "config" segment
+	matchResult := getMatchResult(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config",
+		"/subscriptions/random/resourceGroups/aaaaa/providers/Microsoft.Web/sites/azbrowsetest/config")
+
+	if !matchResult.IsMatch {
+		t.Error("Expected IsMatch to be true")
+	} else {
+		t.Log("verifying values")
+		verifyMap(
+			t,
+			map[string]string{
+				"subscriptionId":    "random",
+				"resourceGroupName": "aaaaa",
+				"name":              "azbrowsetest",
+			},
+			matchResult.Values)
+	}
+}
+func TestMatchWithQueryString(t *testing.T) {
+
+	//shouldn't match because url has extra "config" segment
+	matchResult := getMatchResult(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config",
+		"/subscriptions/random/resourceGroups/aaaaa/providers/Microsoft.Web/sites/azbrowsetest/config?api-version=2020-02-02")
+
+	if !matchResult.IsMatch {
+		t.Error("Expected IsMatch to be true")
+	} else {
+		t.Log("verifying values")
+		verifyMap(
+			t,
+			map[string]string{
+				"subscriptionId":    "random",
+				"resourceGroupName": "aaaaa",
+				"name":              "azbrowsetest",
+			},
+			matchResult.Values)
+	}
+}
+
+func TestBuildWithoutQueryString(t *testing.T) {
+	endpoint, err := GetEndpointInfoFromURL(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config",
+		"")
+	if err != nil {
+		t.Errorf("Expected success but got error: %s", err)
+		return
+	}
+	url, err := endpoint.BuildURL(map[string]string{
+		"subscriptionId":    "123456789",
+		"resourceGroupName": "mygroup",
+		"name":              "mysite",
+	})
+	expectedURL := "/subscriptions/123456789/resourceGroups/mygroup/providers/Microsoft.Web/sites/mysite/config"
+	if err != nil {
+		t.Errorf("Expected success but got error: %s", err)
+		return
+	}
+	if url != expectedURL {
+		t.Errorf("Expected URL '%s' but got '%s", url, expectedURL)
+	}
+}
+func TestBuildWithQueryString(t *testing.T) {
+	endpoint, err := GetEndpointInfoFromURL(
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config",
+		"2020-02-02")
+	if err != nil {
+		t.Errorf("Expected success but got error: %s", err)
+		return
+	}
+	url, err := endpoint.BuildURL(map[string]string{
+		"subscriptionId":    "123456789",
+		"resourceGroupName": "mygroup",
+		"name":              "mysite",
+	})
+	expectedURL := "/subscriptions/123456789/resourceGroups/mygroup/providers/Microsoft.Web/sites/mysite/config?api-version=2020-02-02"
+	if err != nil {
+		t.Errorf("Expected success but got error: %s", err)
+		return
+	}
+	if url != expectedURL {
+		t.Errorf("Expected URL '%s' but got '%s", url, expectedURL)
+	}
+}
+
+func verifyMap(t *testing.T, expected map[string]string, actual map[string]string) {
+
+	for key, value := range expected {
+		if actual[key] != value {
+			t.Errorf("Expected key '%s' to have value '%s' but got '%s'", key, value, actual[key])
+		}
+	}
+
+	if len(actual) != len(expected) {
+		for key := range actual {
+			if expected[key] == "" {
+				t.Errorf("Actual has key '%s' (with value '%s') which was not expected ", key, actual[key])
+			}
+		}
+	}
+}
+
+func getMatchResult(templateURL string, url string) MatchResult {
+	endpoint, _ := GetEndpointInfoFromURL(templateURL, "")
+	// TODO test err
+	matchResult := endpoint.Match(url)
+	return matchResult
+}

--- a/handlers/appservice.go
+++ b/handlers/appservice.go
@@ -19,13 +19,9 @@ type AppServiceResourceExpander struct {
 
 type handledType struct {
 	name     string
+	display  string
 	endpoint endpoints.EndpointInfo
-	children []child
-}
-
-type child struct {
-	Display  string
-	Endpoint endpoints.EndpointInfo
+	children []handledType
 }
 
 // Name returns the name of the expander
@@ -39,60 +35,56 @@ func (e *AppServiceResourceExpander) ensureInitialized() {
 			{
 				name:     "site",
 				endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}", "2018-02-01"),
-				children: []child{
+				children: []handledType{
 					{
-						Display:  "config",
-						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
+						display:  "config",
+						endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
+						children: []handledType{
+							{
+								display:  "appsettings",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "authsettings",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "connectionstrings",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "logs",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/logs/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "metadata",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "publishingcredentials",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "pushsettings",
+								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/pushsettings/list", "2018-02-01", "POST"),
+							},
+							{
+								display:  "slotConfigNames",
+								endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/slotConfigNames", "2018-02-01"),
+							},
+							{
+								display:  "virtualNetwork",
+								endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/virtualNetwork", "2018-02-01"),
+							},
+							{
+								display:  "web",
+								endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web", "2018-02-01"),
+							},
+						},
 					},
 					{
-						Display:  "siteextensions",
-						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/siteextensions", "2018-02-01"),
-					},
-				},
-			},
-			{
-				name:     "site/config",
-				endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
-				children: []child{
-					{
-						Display:  "appsettings",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "authsettings",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "connectionstrings",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "logs",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/logs/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "metadata",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "publishingcredentials",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "pushsettings",
-						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/pushsettings/list", "2018-02-01", "POST"),
-					},
-					{
-						Display:  "slotConfigNames",
-						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/slotConfigNames", "2018-02-01"),
-					},
-					{
-						Display:  "virtualNetwork",
-						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/virtualNetwork", "2018-02-01"),
-					},
-					{
-						Display:  "web",
-						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web", "2018-02-01"),
+						display:  "siteextensions",
+						endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/siteextensions", "2018-02-01"),
 					},
 				},
 			},
@@ -113,11 +105,15 @@ func getEndpointInfoFromURLWithVerbAndPanicOnError(url string, apiVersion string
 	return endpoint
 }
 
-func (e *AppServiceResourceExpander) getHandledTypeForURL(url string) *handledType {
-	for _, handledType := range e.handledTypes {
+func getHandledTypeForURL(url string, handledTypes []handledType) *handledType {
+	for _, handledType := range handledTypes {
 		matchResult := handledType.endpoint.Match(url)
 		if matchResult.IsMatch {
 			return &handledType
+		}
+		result := getHandledTypeForURL(url, handledType.children)
+		if result != nil {
+			return result
 		}
 	}
 	return nil
@@ -127,7 +123,7 @@ func (e *AppServiceResourceExpander) getHandledTypeForURL(url string) *handledTy
 func (e *AppServiceResourceExpander) DoesExpand(ctx context.Context, currentItem TreeNode) (bool, error) {
 	e.ensureInitialized()
 	if currentItem.ItemType == resourceType {
-		item := e.getHandledTypeForURL(currentItem.ExpandURL)
+		item := getHandledTypeForURL(currentItem.ExpandURL, e.handledTypes)
 		if item != nil {
 			return true, nil
 		}
@@ -142,7 +138,7 @@ func (e *AppServiceResourceExpander) Expand(ctx context.Context, currentItem Tre
 	span, ctx := tracing.StartSpanFromContext(ctx, "expand:"+currentItem.ItemType+":"+currentItem.Name+":"+currentItem.ID, tracing.SetTag("item", currentItem))
 	defer span.Finish()
 
-	handledType := e.getHandledTypeForURL(currentItem.ExpandURL)
+	handledType := getHandledTypeForURL(currentItem.ExpandURL, e.handledTypes)
 	if handledType == nil {
 		panic(fmt.Errorf("Node Item not found"))
 	}
@@ -169,16 +165,16 @@ func (e *AppServiceResourceExpander) Expand(ctx context.Context, currentItem Tre
 	templateValues := matchResult.Values
 	for _, child := range handledType.children {
 
-		url, err := child.Endpoint.BuildURL(templateValues)
+		url, err := child.endpoint.BuildURL(templateValues)
 		if err != nil {
-			err = fmt.Errorf("Error building URL: %s\nURL:%s", child.Display, err)
+			err = fmt.Errorf("Error building URL: %s\nURL:%s", child.display, err)
 			panic(err)
 		}
 		newItems = append(newItems, TreeNode{
 			Parentid:  currentItem.ID,
 			Namespace: "appservice",
-			Name:      child.Display,
-			Display:   child.Display,
+			Name:      child.display,
+			Display:   child.display,
 			ExpandURL: url,
 			ItemType:  resourceType,
 			DeleteURL: "NotSupported",

--- a/handlers/appservice.go
+++ b/handlers/appservice.go
@@ -182,8 +182,8 @@ func (e *AppServiceResourceExpander) Expand(ctx context.Context, currentItem Tre
 	}
 
 	return ExpanderResult{
-		Nodes:    &newItems,
-		Response: string(data),
+		Nodes:             &newItems,
+		Response:          string(data),
 		IsPrimaryResponse: true, // only returning items that we are the primary response for
 	}
 }

--- a/handlers/appservice.go
+++ b/handlers/appservice.go
@@ -184,5 +184,6 @@ func (e *AppServiceResourceExpander) Expand(ctx context.Context, currentItem Tre
 	return ExpanderResult{
 		Nodes:    &newItems,
 		Response: string(data),
+		IsPrimaryResponse: true, // only returning items that we are the primary response for
 	}
 }

--- a/handlers/appservice.go
+++ b/handlers/appservice.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lawrencegripper/azbrowse/endpoints"
+
+	"github.com/lawrencegripper/azbrowse/armclient"
+	"github.com/lawrencegripper/azbrowse/tracing"
+)
+
+// AppServiceResourceExpander expands resource under an AppService
+type AppServiceResourceExpander struct {
+	initialized  bool
+	handledTypes []handledType
+}
+
+type handledType struct {
+	name     string
+	endpoint endpoints.EndpointInfo
+	children []child
+}
+
+type child struct {
+	Display  string
+	Endpoint endpoints.EndpointInfo
+}
+
+// Name returns the name of the expander
+func (e *AppServiceResourceExpander) Name() string {
+	return "AppServiceResourceExpander"
+}
+
+func (e *AppServiceResourceExpander) ensureInitialized() {
+	if !e.initialized {
+		e.handledTypes = []handledType{
+			{
+				name:     "site",
+				endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}", "2018-02-01"),
+				children: []child{
+					{
+						Display:  "config",
+						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
+					},
+					{
+						Display:  "siteextensions",
+						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/siteextensions", "2018-02-01"),
+					},
+				},
+			},
+			{
+				name:     "site/config",
+				endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
+				children: []child{
+					{
+						Display:  "appsettings",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "authsettings",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "connectionstrings",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "logs",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/logs/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "metadata",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "publishingcredentials",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "pushsettings",
+						Endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/pushsettings/list", "2018-02-01", "POST"),
+					},
+					{
+						Display:  "slotConfigNames",
+						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/slotConfigNames", "2018-02-01"),
+					},
+					{
+						Display:  "virtualNetwork",
+						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/virtualNetwork", "2018-02-01"),
+					},
+					{
+						Display:  "web",
+						Endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web", "2018-02-01"),
+					},
+				},
+			},
+		}
+		e.initialized = true
+	}
+}
+
+func getEndpointInfoFromURLAndPanicOnError(url string, apiVersion string) endpoints.EndpointInfo {
+	return getEndpointInfoFromURLWithVerbAndPanicOnError(url, apiVersion, "GET")
+}
+func getEndpointInfoFromURLWithVerbAndPanicOnError(url string, apiVersion string, verb string) endpoints.EndpointInfo {
+	endpoint, err := endpoints.GetEndpointInfoFromURL(url, apiVersion)
+	if err != nil {
+		panic(err)
+	}
+	endpoint.Verb = verb
+	return endpoint
+}
+
+func (e *AppServiceResourceExpander) getHandledTypeForURL(url string) *handledType {
+	for _, handledType := range e.handledTypes {
+		matchResult := handledType.endpoint.Match(url)
+		if matchResult.IsMatch {
+			return &handledType
+		}
+	}
+	return nil
+}
+
+// DoesExpand checks if this is an RG
+func (e *AppServiceResourceExpander) DoesExpand(ctx context.Context, currentItem TreeNode) (bool, error) {
+	e.ensureInitialized()
+	if currentItem.ItemType == resourceType {
+		item := e.getHandledTypeForURL(currentItem.ExpandURL)
+		if item != nil {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Expand returns Resources in the RG
+func (e *AppServiceResourceExpander) Expand(ctx context.Context, currentItem TreeNode) ExpanderResult {
+
+	span, ctx := tracing.StartSpanFromContext(ctx, "expand:"+currentItem.ItemType+":"+currentItem.Name+":"+currentItem.ID, tracing.SetTag("item", currentItem))
+	defer span.Finish()
+
+	handledType := e.getHandledTypeForURL(currentItem.ExpandURL)
+	if handledType == nil {
+		panic(fmt.Errorf("Node Item not found"))
+	}
+
+	method := handledType.endpoint.Verb
+	data, err := armclient.DoRequest(ctx, method, currentItem.ExpandURL)
+	if err != nil {
+		return ExpanderResult{
+			Nodes:    nil,
+			Response: string(data),
+			Err:      fmt.Errorf("Failed" + err.Error() + currentItem.ExpandURL),
+		}
+	}
+
+	var resourceResponse armclient.ResourceReseponse
+	err = json.Unmarshal([]byte(data), &resourceResponse)
+	if err != nil {
+		err = fmt.Errorf("Error unmarshalling response: %s\nURL:%s", err, currentItem.ExpandURL)
+		panic(err)
+	}
+
+	newItems := []TreeNode{}
+	matchResult := handledType.endpoint.Match(currentItem.ExpandURL) // TODO - return the matches from getHandledTypeForURL to avoid re-calculating!
+	templateValues := matchResult.Values
+	for _, child := range handledType.children {
+
+		url, err := child.Endpoint.BuildURL(templateValues)
+		if err != nil {
+			err = fmt.Errorf("Error building URL: %s\nURL:%s", child.Display, err)
+			panic(err)
+		}
+		newItems = append(newItems, TreeNode{
+			Parentid:  currentItem.ID,
+			Namespace: "appservice",
+			Name:      child.Display,
+			Display:   child.Display,
+			ExpandURL: url,
+			ItemType:  resourceType,
+			DeleteURL: "NotSupported",
+		})
+	}
+
+	return ExpanderResult{
+		Nodes:    &newItems,
+		Response: string(data),
+	}
+}

--- a/handlers/appservice.go
+++ b/handlers/appservice.go
@@ -18,7 +18,6 @@ type AppServiceResourceExpander struct {
 }
 
 type handledType struct {
-	name     string
 	display  string
 	endpoint endpoints.EndpointInfo
 	children []handledType
@@ -33,7 +32,6 @@ func (e *AppServiceResourceExpander) ensureInitialized() {
 	if !e.initialized {
 		e.handledTypes = []handledType{
 			{
-				name:     "site",
 				endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}", "2018-02-01"),
 				children: []handledType{
 					{

--- a/handlers/appservice.go
+++ b/handlers/appservice.go
@@ -34,57 +34,57 @@ func (e *AppServiceResourceExpander) ensureInitialized() {
 		e.handledTypes = []handledType{
 			{
 				name:     "site",
-				endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}", "2018-02-01"),
+				endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}", "2018-02-01"),
 				children: []handledType{
 					{
 						display:  "config",
-						endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
+						endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config", "2018-02-01"),
 						children: []handledType{
 							{
 								display:  "appsettings",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/appsettings/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "authsettings",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/authsettings/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "connectionstrings",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/connectionstrings/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "logs",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/logs/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/logs/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "metadata",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/metadata/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "publishingcredentials",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "pushsettings",
-								endpoint: getEndpointInfoFromURLWithVerbAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/pushsettings/list", "2018-02-01", "POST"),
+								endpoint: mustGetEndpointInfoFromURLWithVerb("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/pushsettings/list", "2018-02-01", "POST"),
 							},
 							{
 								display:  "slotConfigNames",
-								endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/slotConfigNames", "2018-02-01"),
+								endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/slotConfigNames", "2018-02-01"),
 							},
 							{
 								display:  "virtualNetwork",
-								endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/virtualNetwork", "2018-02-01"),
+								endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/virtualNetwork", "2018-02-01"),
 							},
 							{
 								display:  "web",
-								endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web", "2018-02-01"),
+								endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/web", "2018-02-01"),
 							},
 						},
 					},
 					{
 						display:  "siteextensions",
-						endpoint: getEndpointInfoFromURLAndPanicOnError("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/siteextensions", "2018-02-01"),
+						endpoint: mustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/siteextensions", "2018-02-01"),
 					},
 				},
 			},
@@ -93,10 +93,10 @@ func (e *AppServiceResourceExpander) ensureInitialized() {
 	}
 }
 
-func getEndpointInfoFromURLAndPanicOnError(url string, apiVersion string) endpoints.EndpointInfo {
-	return getEndpointInfoFromURLWithVerbAndPanicOnError(url, apiVersion, "GET")
+func mustGetEndpointInfoFromURL(url string, apiVersion string) endpoints.EndpointInfo {
+	return mustGetEndpointInfoFromURLWithVerb(url, apiVersion, "GET")
 }
-func getEndpointInfoFromURLWithVerbAndPanicOnError(url string, apiVersion string, verb string) endpoints.EndpointInfo {
+func mustGetEndpointInfoFromURLWithVerb(url string, apiVersion string, verb string) endpoints.EndpointInfo {
 	endpoint, err := endpoints.GetEndpointInfoFromURL(url, apiVersion)
 	if err != nil {
 		panic(err)

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -33,6 +33,7 @@ var Register = []Expander{
 	&ResourceGroupResourceExpander{},
 	&SubscriptionExpander{},
 	&ActionExpander{},
+	&AppServiceResourceExpander{},
 }
 
 // TreeNode is an item in the ListWidget

--- a/treeview.go
+++ b/treeview.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/lawrencegripper/azbrowse/eventing"
 	"strings"
 	"time"
+
+	"github.com/lawrencegripper/azbrowse/eventing"
 
 	"github.com/lawrencegripper/azbrowse/tracing"
 
@@ -245,7 +246,7 @@ func (w *ListWidget) ExpandCurrentSelection() {
 
 	// Update the list if we have sub items from the expanders
 	// or return the default experience for and unknown item
-	if len(newItems) > 0 {
+	if hasPrimaryResponse || len(newItems) > 0 {
 		w.items = newItems
 		w.selected = 0
 	}


### PR DESCRIPTION
AppServiceExpander is currently a partial implementation of AppService specific functionality. The goal is to use this to explore further integration that can be driven from the ARM API Swagger definitions.

Bonus addition in this PR is the addition of `launch.json` config to set up interactive debugging of azbrowse running in a separate terminal.