### PR TITLE
Make the Sun Shine on MacOS and Fix #55

### DIFF
--- a/cmd/azbrowse/help.go
+++ b/cmd/azbrowse/help.go
@@ -17,42 +17,42 @@ func ToggleHelpView(g *gocui.Gui) {
 func DrawHelp(v *gocui.View) {
 
 	fmt.Fprint(v, style.Header(`
-	--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--
-                             _       ___
-                            /_\   __| _ )_ _ _____ __ _____ ___
-                           / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)
-                          /_/ \_\/__|___/_| \___/\_/\_//__/\___|
-                        Interactive CLI for browsing Azure resources
-# Navigation
-
-| Key         | Does                 |
-| ----------- | -------------------- |
-| ⇧ / ⇩       | Select resource      |
-| ⇦ / ⇨       | Select Menu/JSON     |
-| Backspace   | Go back              |
-| ENTER       | Expand/View resource |
-| F5          | Refresh              |
-| CTRL+I      | Show this page       |
-
-# Operations
-
-| Key                 | Does                      |                                                                                    |
-| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- |
-| CTRL+E              | Toggle Browse JSON        | For longer responses you can move the cursor to scroll the doc                     |
-| CTLT+F              | Toggle Fullscreen         | Gives a fullscreen view of the JSON for smaller terminals                          |
-| CTRL+O (o for open) | Open Portal               | Opens the portal at the currently selected resource                                |
-| DEL                 | Delete resource           | The currently selected resource will be deleted (Requires double press to confirm) |
-| CTLT+S              | Save JSON to clipboard    | Saves the last JSON response to the clipboard for export                           |
-| CTLT+A              | View Actions for resource | This allows things like ListKeys on storage or Restart on VMs                      |
-
-For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse
-
-# Status Icons
-
-Deleting: ☠ Failed: ⛈  Updating: ⟳  Resuming/Starting:    ⛅  Provisioning: ⌛
-Creating\Preparing: 🏗  Scaling:  ⚖   Suspended/Suspending: ⛔  Succeeded:   ☼
-
---> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--
+	--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--                                                                                                                                  
+                             _       ___                                                                                                                                                                                                 
+                            /_\   __| _ )_ _ _____ __ _____ ___                                                                                                                                                                          
+                           / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)                                                                                                                                                                         
+                          /_/ \_\/__|___/_| \___/\_/\_//__/\___|                                                                                                                                                                         
+                        Interactive CLI for browsing Azure resources                                                                                                                                                                     
+# Navigation                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                
+| Key         | Does                 |                                                                                                                                                                                                                                              
+| ----------- | -------------------- |                                                                                                                                                                                                                                              
+| ⇧ / ⇩       | Select resource      |                                                                                                                                                                                                                                              
+| ⇦ / ⇨       | Select Menu/JSON     |                                                                                                                                                                                                                                                             
+| Backspace   | Go back              |                                                                                                                                                                                                           
+| ENTER       | Expand/View resource |                                                                                                                                                                                                           
+| F5          | Refresh              |                                                                                                                                                                                                           
+| CTRL+I      | Show this page       |                                                                                                                                                                                                           
+                                                                                                                                                                                                           
+# Operations	                                                                                                                                                                                                           
+                                                                                                                                                                                                           
+| Key                 | Does                      |                                                                                    |                                                                                                                                                                                                           
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- |                                                                                                                                                                                                           
+| CTRL+E              | Toggle Browse JSON        | For longer responses you can move the cursor to scroll the doc                     |                                                                                                                                                                                                           
+| CTLT+F              | Toggle Fullscreen         | Gives a fullscreen view of the JSON for smaller terminals                          |                                                                                                                                                                                                           
+| CTRL+O (o for open) | Open Portal               | Opens the portal at the currently selected resource                                |                                                                                                                                                                                                           
+| DEL                 | Delete resource           | The currently selected resource will be deleted (Requires double press to confirm) |                                                                                                                                                                                                           
+| CTLT+S              | Save JSON to clipboard    | Saves the last JSON response to the clipboard for export                           |                                                                                                                                                                                                           
+| CTLT+A              | View Actions for resource | This allows things like ListKeys on storage or Restart on VMs                      |                                                                                                                                                                                                           
+                                                                                                                                                                                                           
+For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse                                                                                                                                                                                                                                 
+                                                                                                                                                                                                           
+# Status Icons                                                                                                                                                                                                           
+                                                                                                                                                                                                           
+Deleting: ☠ Failed: ⛈  Updating: ⟳  Resuming/Starting:    ⛅  Provisioning: ⌛                                                                                                                                                                                                            
+Creating\Preparing: 🏗  Scaling:  ⚖   Suspended/Suspending: ⛔  Succeeded:   ☼                                                                                                                                                                                                                                                             
+                                                                                                                                                                                                                                                                                                                                                            
+--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--                                                                                                                                                                                                            
 
 `))
 

--- a/cmd/azbrowse/help.go
+++ b/cmd/azbrowse/help.go
@@ -17,42 +17,42 @@ func ToggleHelpView(g *gocui.Gui) {
 func DrawHelp(v *gocui.View) {
 
 	fmt.Fprint(v, style.Header(`
-	--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--                                                                                                                                  
-                             _       ___                                                                                                                                                                                                 
-                            /_\   __| _ )_ _ _____ __ _____ ___                                                                                                                                                                          
-                           / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)                                                                                                                                                                         
-                          /_/ \_\/__|___/_| \___/\_/\_//__/\___|                                                                                                                                                                         
-                        Interactive CLI for browsing Azure resources                                                                                                                                                                     
-# Navigation                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                                
-| Key         | Does                 |                                                                                                                                                                                                                                              
-| ----------- | -------------------- |                                                                                                                                                                                                                                              
-| ⇧ / ⇩       | Select resource      |                                                                                                                                                                                                                                              
-| ⇦ / ⇨       | Select Menu/JSON     |                                                                                                                                                                                                                                                             
-| Backspace   | Go back              |                                                                                                                                                                                                           
-| ENTER       | Expand/View resource |                                                                                                                                                                                                           
-| F5          | Refresh              |                                                                                                                                                                                                           
-| CTRL+I      | Show this page       |                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-# Operations	                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-| Key                 | Does                      |                                                                                    |                                                                                                                                                                                                           
-| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- |                                                                                                                                                                                                           
-| CTRL+E              | Toggle Browse JSON        | For longer responses you can move the cursor to scroll the doc                     |                                                                                                                                                                                                           
-| CTLT+F              | Toggle Fullscreen         | Gives a fullscreen view of the JSON for smaller terminals                          |                                                                                                                                                                                                           
-| CTRL+O (o for open) | Open Portal               | Opens the portal at the currently selected resource                                |                                                                                                                                                                                                           
-| DEL                 | Delete resource           | The currently selected resource will be deleted (Requires double press to confirm) |                                                                                                                                                                                                           
-| CTLT+S              | Save JSON to clipboard    | Saves the last JSON response to the clipboard for export                           |                                                                                                                                                                                                           
-| CTLT+A              | View Actions for resource | This allows things like ListKeys on storage or Restart on VMs                      |                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse                                                                                                                                                                                                                                 
-                                                                                                                                                                                                           
-# Status Icons                                                                                                                                                                                                           
-                                                                                                                                                                                                           
-Deleting: ☠ Failed: ⛈  Updating: ⟳  Resuming/Starting:    ⛅  Provisioning: ⌛                                                                                                                                                                                                            
-Creating\Preparing: 🏗  Scaling:  ⚖   Suspended/Suspending: ⛔  Succeeded:   🌣                                                                                                                                                                                                                                                             
-                                                                                                                                                                                                                                                                                                                                                            
---> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--                                                                                                                                                                                                            
+	--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--
+                             _       ___
+                            /_\   __| _ )_ _ _____ __ _____ ___
+                           / _ \ |_ / _ \ '_/ _ \ V  V (_-</ -_)
+                          /_/ \_\/__|___/_| \___/\_/\_//__/\___|
+                        Interactive CLI for browsing Azure resources
+# Navigation
+
+| Key         | Does                 |
+| ----------- | -------------------- |
+| ⇧ / ⇩       | Select resource      |
+| ⇦ / ⇨       | Select Menu/JSON     |
+| Backspace   | Go back              |
+| ENTER       | Expand/View resource |
+| F5          | Refresh              |
+| CTRL+I      | Show this page       |
+
+# Operations
+
+| Key                 | Does                      |                                                                                    |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- |
+| CTRL+E              | Toggle Browse JSON        | For longer responses you can move the cursor to scroll the doc                     |
+| CTLT+F              | Toggle Fullscreen         | Gives a fullscreen view of the JSON for smaller terminals                          |
+| CTRL+O (o for open) | Open Portal               | Opens the portal at the currently selected resource                                |
+| DEL                 | Delete resource           | The currently selected resource will be deleted (Requires double press to confirm) |
+| CTLT+S              | Save JSON to clipboard    | Saves the last JSON response to the clipboard for export                           |
+| CTLT+A              | View Actions for resource | This allows things like ListKeys on storage or Restart on VMs                      |
+
+For bugs, issue or to contribute visit: https://github.com/lawrencegripper/azbrowse
+
+# Status Icons
+
+Deleting: ☠ Failed: ⛈  Updating: ⟳  Resuming/Starting:    ⛅  Provisioning: ⌛
+Creating\Preparing: 🏗  Scaling:  ⚖   Suspended/Suspending: ⛔  Succeeded:   ☼
+
+--> PRESS CTRL+I TO CLOSE THIS AND CONTINUE. YOU CAN OPEN IT AGAIN WITH CRTL+I AT ANY TIME. <--
 
 `))
 

--- a/internal/pkg/handlers/utils.go
+++ b/internal/pkg/handlers/utils.go
@@ -38,7 +38,7 @@ func DrawStatus(s string) string {
 	case "Suspending":
 		return "⛔"
 	case "Succeeded":
-		return "🌣"
+		return "☼"
 	}
 	return ""
 }


### PR DESCRIPTION
Fixes https://github.com/lawrencegripper/azbrowse/issues/55 by replacing the current "white sun" glyph...

https://unicode-table.com/en/1F323/

... with the "white sun with rays" glyph...

https://unicode-table.com/en/263C/

... as the former appears to be unsupported on MacOS