### PR TITLE
Change keybindings file to more generic config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The `AzureDevOps` build run the integration tests under `XTerm`.
 ### Running locally
 
 ``` bash
-make integration && make ci-docker 
+make integration && make ci-docker
 ```
 
 To run the full Travis-CI locally, you need to have the `TRAVIS_BUILD_NUMBER` environment variable defined, so running it as follows may be easier:
@@ -172,15 +172,18 @@ TRAVIS_BUILD_NUMBER=0.1 make ci-docker
 
 ## Custom Key Bindings
 
-If you wish to override the default key bindings, create a `~/.azbrowse-bindings.json` file (where `~` is your users home directory).
+If you wish to override the default key bindings, create a `~/.azbrowse-settings.json` file (where `~` is your users home directory).
 
 The file should be formated like so:
+
 ```json
 {
-    ...
-    "Copy": "F8",
-    "Help": "Ctrl+H",
-    ...
+    "keyBindings": {
+        ...
+        "Copy": "F8",
+        "Help": "Ctrl+H",
+        ...
+    }
 }
 ```
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	KeyBindings map[string]string `json:"keyBindings,omitempty"`
 }
 
+// Load the user configuration settings
 func Load() (Config, error) {
 	var config Config
 	configLocation := "/root/.azbrowse-settings.json"

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+)
+
+// Config represents the user configuration options
+type Config struct {
+	KeyBindings map[string]string `json:"keyBindings,omitempty"`
+}
+
+func Load() (Config, error) {
+	var config Config
+	configLocation := "/root/.azbrowse-settings.json"
+	user, err := user.Current()
+	if err == nil {
+		configLocation = user.HomeDir + "/.azbrowse-settings.json"
+	}
+	_, err = os.Stat(configLocation)
+	if err != nil {
+		// don't error on no config file
+		return config, nil
+	}
+	configFile, err := os.Open(configLocation)
+	if err != nil {
+		return config, err
+	}
+	defer configFile.Close() //nolint: errcheck
+	bytes, _ := ioutil.ReadAll(configFile)
+	if err := json.Unmarshal(bytes, &config); err != nil {
+		return config, err
+	}
+	return config, nil
+}

--- a/internal/pkg/keybindings/bindings.go
+++ b/internal/pkg/keybindings/bindings.go
@@ -1,15 +1,12 @@
 package keybindings
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/user"
 	"strings"
 
 	"github.com/jroimartin/gocui"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/config"
 )
 
 // KeyMap reprsents the current mappings from Handler -> Key
@@ -21,17 +18,11 @@ var usedKeys map[string]string
 
 // Bind sets up key bindings for AzBrowse
 func Bind(g *gocui.Gui) error {
-	configLocation := "/root/.azbrowse-bindings.json"
-	user, err := user.Current()
-	if err == nil {
-		configLocation = user.HomeDir + "/.azbrowse-bindings.json"
-	}
-	defaultFilePath := configLocation
-	keyOverrideSettings, err := loadBindingsFromFile(defaultFilePath)
+	config, err := config.Load()
 	if err != nil {
 		return err
 	}
-	return bindWithConfigOverrides(g, keyOverrideSettings)
+	return bindWithConfigOverrides(g, config.KeyBindings)
 }
 
 func bindWithConfigOverrides(g *gocui.Gui, keyOverrideSettings map[string]string) error {
@@ -123,20 +114,6 @@ func initializeOverrides(keyOverrideSettings map[string]string) error {
 	}
 
 	return nil
-}
-
-func loadBindingsFromFile(filePath string) (map[string]string, error) {
-	jsonf, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer jsonf.Close() //nolint: errcheck
-	bytes, _ := ioutil.ReadAll(jsonf)
-	var keyOverrideSettings map[string]string
-	if err := json.Unmarshal(bytes, &keyOverrideSettings); err != nil {
-		return nil, err
-	}
-	return keyOverrideSettings, nil
 }
 
 func parseKeyValues(keyOverrideSettings map[string]string) (KeyMap, error) {


### PR DESCRIPTION
Migrate `.azbrowse-bindings.json` to `.azbrowse-settings.json`

This change opens up reuse of a single file to hold other settings for azbrowse. The original content of `.azbrowse-bindings.json` because a `keyBindings` property in the new `.azbrowse-settings.json` file.

So 

```json
{
    "Help": "F12"
}
```

becomes

```json
{
    "keyBindings": {
        "Help": "F12"
    }
}
```
