### PR TITLE
Make the ListUpdate editor configurable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "env": {},
             "args": [],
             // run azbrowse in a terminal with the following command before starting the debugger
-            // go build &&  dlv exec ./azbrowse --headless --listen localhost:2345 --api-version 2
+            // go build ./cmd/azbrowse &&  dlv exec ./azbrowse --headless --listen localhost:2345 --api-version 2
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -191,25 +191,26 @@ In the file you can override the keys for actions using keys from the lists belo
 
 ### Actions
 
-| Actions:       | Does                                  |
-| ------------------------ | --------------------------------------|
-| Quit                     | Terminates the program                |
-| Copy                     | Copies the resource JSON to clipboard |
-| ListDelete               | Deletes a resources                   |
-| Fullscreen               | Toggles fullscreen                    |
-| Help                     | Toggles help view                     |
-| ItemBack                 | Go back from an item to a list        |
-| ItemLeft                 | Switch from the item json to the menu |
-| ListActions              | List available actions on a resource  |
-| ListBack                 | Go back on a list                     |
-| ListBackLegacy           | Go back on a list (legacy terminals)  |
-| ListDown                 | Navigate down a list                  |
-| ListUp                   | Navigate up a list                    |
-| ListRight                | Switch from the list to an item view  |
-| ListEdit                 | Toggle edit mode on a resource        |
-| ListExpand               | Expand a selected resource            |
-| ListOpen                 | Open a resource in the Azure portal   |
-| ListRefresh              | Refresh a list                        |
+| Actions:                 | Does                                          |
+| ------------------------ | ----------------------------------------------|
+| Quit                     | Terminates the program                        |
+| Copy                     | Copies the resource JSON to clipboard         |
+| ListDelete               | Deletes a resources                           |
+| Fullscreen               | Toggles fullscreen                            |
+| Help                     | Toggles help view                             |
+| ItemBack                 | Go back from an item to a list                |
+| ItemLeft                 | Switch from the item json to the menu         |
+| ListActions              | List available actions on a resource          |
+| ListBack                 | Go back on a list                             |
+| ListBackLegacy           | Go back on a list (legacy terminals)          |
+| ListDown                 | Navigate down a list                          |
+| ListUp                   | Navigate up a list                            |
+| ListRight                | Switch from the list to an item view          |
+| ListEdit                 | Toggle edit mode on a resource                |
+| ListExpand               | Expand a selected resource                    |
+| ListOpen                 | Open a resource in the Azure portal           |
+| ListRefresh              | Refresh a list                                |
+| ListUpdate               | Open JSON editor to allow updating a resource |
 
 ### Keys
 
@@ -281,6 +282,35 @@ In the file you can override the keys for actions using keys from the lists belo
 - F12
 
 > For compatibility reasons you may notice some keys will have multiple mappings.
+
+## Editing JSON
+
+For items in the tree that are editable (i.e. have a `PUT` endpoint), the `ListUpdate` action will open an editor for you to make changes and then issue the `PUT` request to update the item once you have closed the file. By default this is configured to use [Visual Studio Code](https://code.visualstudio.com).
+
+If you wish to override the default editor, create a `~/.azbrowse-settings.json` file (where `~` is your users home directory).
+
+The file should be formated like so:
+
+```json
+{
+    "editor": {
+        "command": {
+            "executable": "code",
+            "args" : [ "--wait" ]
+        },
+        "translateFilePathForWSL" : "true",
+        "tempDir" : "~/tmp"
+    }
+}
+```
+
+The `command` has two parts, `executable` and `args`. The filename to edit is automatically appended to the `args`. In the example above you can see the `--wait` argument specified which instructs the VS Code executable to not exit until the file is closed. This is important as it is how azbrowse determines that you have finished editing the file and it should perform the `PUT` request.
+
+The `translateFilePathForWSL` property controls whether the path should be converted from a Linux path to a Windows path using the `wslpath` command. This is useful when running azbrwose under [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) and a Windows editor as it converts the temp file path to one that the Windows application can understand.
+
+The `tempDir` property lets you control where the temporary JSON files are written should you have a requirement to not put them in the OS temp location.
+
+The default configuration uses VS Code as the editor as shown above, and dynamically determines whether to perform the WSL file path translation.
 
 ## Plans
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -19,9 +19,11 @@ type EditorConfig struct {
 	TranslateFilePathForWSL bool          `json:"translateFilePathForWSL,omitEmpty"` // WSL use only. True to translate the path to a Windows path (e.g. when running under WSL but using a Windows editor)
 	TempDir                 string        `json:"tempDir,omitempty"`                 // Specify the directory to use for temporary files for editing (defaults to OS temp dir)
 }
+
+// CommandConfig respresents the options for launching a command
 type CommandConfig struct {
 	Executable string   `json:"executable,omitempty"` // The program to run
-	Arguments  []string `json:"args,omitempty"`      // The arguments to pass to the executable (filename will automatically be appended)
+	Arguments  []string `json:"args,omitempty"`       // The arguments to pass to the executable (filename will automatically be appended)
 }
 
 // Load the user configuration settings

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -10,6 +10,18 @@ import (
 // Config represents the user configuration options
 type Config struct {
 	KeyBindings map[string]string `json:"keyBindings,omitempty"`
+	Editor      EditorConfig      `json:"editor,omitempty"`
+}
+
+// EditorConfig represents the user options for external editor
+type EditorConfig struct {
+	Command                 CommandConfig `json:"command,omitempty"`                 // The command to execute to launch the editor
+	TranslateFilePathForWSL bool          `json:"translateFilePathForWSL,omitEmpty"` // WSL use only. True to translate the path to a Windows path (e.g. when running under WSL but using a Windows editor)
+	TempDir                 string        `json:"tempDir,omitempty"`                 // Specify the directory to use for temporary files for editing (defaults to OS temp dir)
+}
+type CommandConfig struct {
+	Executable string   `json:"executable,omitempty"` // The program to run
+	Arguments  []string `json:"args,omitempty"`      // The arguments to pass to the executable (filename will automatically be appended)
 }
 
 // Load the user configuration settings


### PR DESCRIPTION
This PR makes the editor used for the ListUpdate action configurable.

The editor command and arguments can be configured in addition to controlling whether the temp file path should be converted from Linux to Windows paths under WSL. By default VS Code is still used as the editor and whether or not to translate the path is dynamically determined.

Note: currently this only supports graphical editors. Terminal-based editors still need more work - see #96 