### PR TITLE
Add expander to allow access to Storage Management Policies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "name": "Connect to server",
             "type": "go",
-            "request": "launch",
+            "request": "attach",
             "mode": "remote",
             "remotePath": "${workspaceFolder}",
             "port": 2345,

--- a/internal/pkg/handlers/register.go
+++ b/internal/pkg/handlers/register.go
@@ -11,4 +11,5 @@ var Register = []Expander{
 	&DeploymentsExpander{},
 	&ActivityLogExpander{},
 	&JSONExpander{},
+	&StorageManagementPoliciesExpander{}, // Needs to be registered after SwaggerResourceExpander as it depends on SwaggerResourceType being set
 }

--- a/internal/pkg/handlers/storageManagementPolicies.go
+++ b/internal/pkg/handlers/storageManagementPolicies.go
@@ -21,7 +21,7 @@ func (e *StorageManagementPoliciesExpander) Name() string {
 // DoesExpand checks if this is a storage account
 func (e *StorageManagementPoliciesExpander) DoesExpand(ctx context.Context, currentItem *TreeNode) (bool, error) {
 	swaggerResourceType := currentItem.SwaggerResourceType
-	if currentItem.ItemType == "resource"  && swaggerResourceType != nil {
+	if currentItem.ItemType == "resource" && swaggerResourceType != nil {
 		if swaggerResourceType.Endpoint.TemplateURL == "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}" {
 			return true, nil
 		}
@@ -40,13 +40,13 @@ func (e *StorageManagementPoliciesExpander) Expand(ctx context.Context, currentI
 
 		matchResult := swaggerResourceType.Endpoint.Match(currentItem.ExpandURL) // TODO - return the matches from getHandledTypeForURL to avoid re-calculating!
 		templateValues := matchResult.Values
-	
+
 		if swaggerResourceType.SubResources != nil {
 			for _, resourceType := range swaggerResourceType.SubResources {
 				if resourceType.Endpoint.TemplateURL == "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}" {
 					// got the management policies endpoint
 					// now create the expand URL etc etc
-					
+
 					defaultPolicyTemplateValues := make(map[string]string)
 					for k, v := range templateValues {
 						defaultPolicyTemplateValues[k] = v
@@ -55,7 +55,7 @@ func (e *StorageManagementPoliciesExpander) Expand(ctx context.Context, currentI
 
 					url, err := resourceType.Endpoint.BuildURL(defaultPolicyTemplateValues)
 					if err != nil {
-						return ExpanderResult {
+						return ExpanderResult{
 							Err: err,
 						}
 					}
@@ -67,8 +67,8 @@ func (e *StorageManagementPoliciesExpander) Expand(ctx context.Context, currentI
 						ItemType:            SubResourceType,
 						ExpandURL:           url,
 						SwaggerResourceType: &resourceType,
-					})			
-			
+					})
+
 					break
 				}
 			}

--- a/internal/pkg/handlers/storageManagementPolicies.go
+++ b/internal/pkg/handlers/storageManagementPolicies.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+)
+
+// The storage API currently doesn't provide a way to list management policies for a storage account
+// I.e. no GET /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies
+// This means that there is no way to navigate via swagger from the account to the management policies
+// Any policy that exists also currently has to have the name "default" (i.e. can only actually have 0 or 1)
+// This expander adds the link from storage account to management policy
+
+// StorageManagementPoliciesExpander expands The default management policy under a storage account
+type StorageManagementPoliciesExpander struct{}
+
+// Name returns the name of the expander
+func (e *StorageManagementPoliciesExpander) Name() string {
+	return "StorageManagementPoliciesExpander"
+}
+
+// DoesExpand checks if this is a storage account
+func (e *StorageManagementPoliciesExpander) DoesExpand(ctx context.Context, currentItem *TreeNode) (bool, error) {
+	swaggerResourceType := currentItem.SwaggerResourceType
+	if currentItem.ItemType == "resource"  && swaggerResourceType != nil {
+		if swaggerResourceType.Endpoint.TemplateURL == "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Expand returns ManagementPolicies in the StorageAccount
+func (e *StorageManagementPoliciesExpander) Expand(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+	isPrimaryResponse := false
+
+	newItems := []*TreeNode{}
+
+	swaggerResourceType := currentItem.SwaggerResourceType
+	if swaggerResourceType.Endpoint.TemplateURL == "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}" {
+
+		matchResult := swaggerResourceType.Endpoint.Match(currentItem.ExpandURL) // TODO - return the matches from getHandledTypeForURL to avoid re-calculating!
+		templateValues := matchResult.Values
+	
+		if swaggerResourceType.SubResources != nil {
+			for _, resourceType := range swaggerResourceType.SubResources {
+				if resourceType.Endpoint.TemplateURL == "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}" {
+					// got the management policies endpoint
+					// now create the expand URL etc etc
+					
+					defaultPolicyTemplateValues := make(map[string]string)
+					for k, v := range templateValues {
+						defaultPolicyTemplateValues[k] = v
+					}
+					defaultPolicyTemplateValues["managementPolicyName"] = "default"
+
+					url, err := resourceType.Endpoint.BuildURL(defaultPolicyTemplateValues)
+					if err != nil {
+						return ExpanderResult {
+							Err: err,
+						}
+					}
+					newItems = append(newItems, &TreeNode{
+						Parentid:            currentItem.ID,
+						Namespace:           "storageManagementPolicies",
+						Name:                "ManagementPolicy",
+						Display:             "Management Policy",
+						ItemType:            SubResourceType,
+						ExpandURL:           url,
+						SwaggerResourceType: &resourceType,
+					})			
+			
+					break
+				}
+			}
+		}
+	}
+
+	return ExpanderResult{
+		Err:               nil,
+		Response:          "TODO",
+		SourceDescription: "StorageManagementPoliciesExpander request",
+		Nodes:             newItems,
+		IsPrimaryResponse: isPrimaryResponse,
+	}
+}


### PR DESCRIPTION
The storage API currently doesn't provide a way to list management policies for a storage account
I.e. no `GET` `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies`
This means that there is no way to navigate via swagger from the account to the management policies
Any policy that exists also currently has to have the name "default" (i.e. can only actually have 0 or 1)
This PR adds an expander that adds the link from storage account to management policy to enable viewing/updating the policy