### PR TITLE
Flag then close stale issues or PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Flagging stale issue. Actions will close this issue in the next 5 days unless action is taken.'
+        stale-pr-message: 'Flagging stale pull request. Actions will close this PR in the next 5 days unless action is taken. Tag with awaiting-approval to avoid.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 30
+        days-before-close: 5
+        exempt-issue-label: 'no-stale'
+        exempt-pr-label: 'awaiting-approval'


### PR DESCRIPTION
This will flag then close stale issues and PRs. 

Setting `no-stale` on an issue or `awaiting-approval` on a PR should prevent them being closed if currently blocked. 