### PR TITLE
Fix issues from navigate command changes

### DIFF
--- a/internal/pkg/handlers/metrics.go
+++ b/internal/pkg/handlers/metrics.go
@@ -94,6 +94,7 @@ func expandMetricNamespace(ctx context.Context, currentItem *TreeNode) ExpanderR
 			Metadata: map[string]string{
 				"SuppressSwaggerExpand": "true",
 				"SuppressGenericExpand": "true",
+				"ResourceID":            currentItem.ID,
 			},
 		})
 	}
@@ -129,9 +130,9 @@ func expandMetricDefinition(ctx context.Context, currentItem *TreeNode) Expander
 		newItems = append(newItems, &TreeNode{
 			Name:     metric.Name.Value,
 			Display:  metric.Name.Value + "\n  " + style.Subtle("Unit: "+metric.Unit),
-			ID:       currentItem.ID + "/providers/microsoft.Insights/metrics",
+			ID:       currentItem.Metadata["ResourceID"] + "/providers/microsoft.Insights/metrics",
 			Parentid: currentItem.ID,
-			ExpandURL: currentItem.ID + "/providers/microsoft.Insights/metrics?timespan=" +
+			ExpandURL: currentItem.Metadata["ResourceID"] + "/providers/microsoft.Insights/metrics?timespan=" +
 				time.Now().UTC().Add(-4*time.Hour).Format("2006-01-02T15:04:05.000Z") + "/" +
 				time.Now().UTC().Format("2006-01-02T15:04:05.000Z") + "&interval=PT1M&metricnames=" +
 				url.QueryEscape(metric.Name.Value) + "&aggregation=" +

--- a/internal/pkg/handlers/swagger.go
+++ b/internal/pkg/handlers/swagger.go
@@ -144,6 +144,7 @@ func (e *SwaggerResourceExpander) Expand(ctx context.Context, currentItem *TreeN
 				Namespace:           "swagger",
 				Name:                name,
 				Display:             name,
+				ID:                  resource.ID,
 				ExpandURL:           resource.ID + "?api-version=" + subResourceType.Endpoint.APIVersion,
 				ItemType:            SubResourceType,
 				DeleteURL:           deleteURL,
@@ -169,6 +170,7 @@ func (e *SwaggerResourceExpander) Expand(ctx context.Context, currentItem *TreeN
 		}
 		newItems = append(newItems, &TreeNode{
 			Parentid:            currentItem.ID,
+			ID:                  currentItem.ID + "/" + display,
 			Namespace:           "swagger",
 			Name:                display,
 			Display:             display,

--- a/internal/pkg/views/treeview.go
+++ b/internal/pkg/views/treeview.go
@@ -218,7 +218,11 @@ func (w *ListWidget) ExpandCurrentSelection() {
 				continue
 			}
 			// Add the items it found
-			newItems = append(newItems, done.Nodes...)
+			if done.IsPrimaryResponse {
+				newItems = append(done.Nodes, newItems...)
+			} else {
+				newItems = append(newItems, done.Nodes...)
+			}
 			span.Finish()
 		case <-timeout:
 			eventing.SendStatusEvent(eventing.StatusEvent{


### PR DESCRIPTION
Add node IDs in Swagger handler to fix `A crash occurred: ids must be unique or the navigate command breaks` error