### PR TITLE
Added az cli install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,6 +54,9 @@ RUN apt-get update \
         github.com/mgechev/revive \
         github.com/derekparker/delve/cmd/dlv 2>&1 \
     #
+    # Install Azure CLI
+    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
+    #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \


### PR DESCRIPTION
Just adding the Azure CLI installation to the Dev Dockerfile to address #131 
We could add config to devcontainer.json to mount .azure but this doesn't currently work in WSL2 because if you launch VSCode in WSL2 it actually opens in Windows using the WSL Remote Dev extension, this stops you then being able to open the directory using the SSH Remote Dev extension. So you have to launch code directly in Windows with the source code on your Windows FS and setup Docker for Desktop Tech Preview to spin up a docker container in WSL. This works ok but means the mount path would have to be relative to your Windows Filesystem i.e. `\\wsl$\Ubuntu\home\jjcollinge`. I'm not sure how configurable the `devcontainer.json` file is so I haven't added this.