### PR TITLE
Add change of ownership for GOPATH for Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -62,6 +62,9 @@ RUN apt-get update \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
+    # Change GOPATH ownership
+    && chown -R $USERNAME /go \
+    #
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
Added a change of ownership for the GOPATH in the Dev container Dockerfile.
Without this I was getting permission issues when building.

issue: #130 