### PR TITLE
Temp fix for slice bounds out of range

### DIFF
--- a/pkg/endpoints/endpointinfo.go
+++ b/pkg/endpoints/endpointinfo.go
@@ -110,7 +110,7 @@ func (ei *EndpointInfo) Match(url string) MatchResult {
 			return MatchResult{IsMatch: false}
 		}
 		remainingURLToMatch = remainingURLToMatch[len(segment.Prefix):]
-		if segment.Match != "" {
+		if segment.Match != "" && len(remainingURLToMatch) > len(segment.Match) {
 			// literal match - check (case-insensitively) that the remainingURL starts with segment.Match
 			matchTest := remainingURLToMatch[:len(segment.Match)]
 			if strings.EqualFold(segment.Match, matchTest) {


### PR DESCRIPTION
@stuartleeks this prevents a crash due to #148 but it does leave the sub-resource unpopulated.