### PR TITLE
Remove panic on timeout/error expanding list

### DIFF
--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -214,12 +214,9 @@ func (w *ListWidget) ExpandCurrentSelection() {
 	newTitle := fmt.Sprintf("[%s-> Fullscreen|%s -> Actions] %s", strings.ToUpper(w.FullscreenKeyBinding), strings.ToUpper(w.ActionKeyBinding), currentItem.Name)
 
 	newContent, newItems, err := expanders.ExpandItem(w.ctx, currentItem)
-	if err != nil {
-		// Shouldn't be possible
-		panic(err)
+	if err == nil { // expander emits status event on error
+		w.Navigate(newItems, newContent, newTitle)
 	}
-
-	w.Navigate(newItems, newContent, newTitle)
 }
 
 // Navigate updates the currently selected list nodes, title and details content


### PR DESCRIPTION
Fixes #171 

Have tested this change with a code-change to add a sleep in the expander and confirm that a status message is output and that you can retry