### PR TITLE
bugfix: fuzzer got stuck on empty subscription

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+The aim of this doc is to capture some of the patterns for working with azbrowse to add new providers or other features.
+
+If using [Visual Studio Code](https://code.visualstudio.com) and you have the Remote Development extension (+Docker) installed then you can take advantage of the devcontainer support to have a development environment set up ready for you to use.
+
+## Expanders
+
+The hierarchical drill-down from Subscription -> Resource Group -> Resource -> ... is driven by Expanders. These are registered in `registerExpanders.go` and when the list widget expands a node it calls each expander asking if they have any nodes to provide. Multiple expanders can return nodes for any given parent node, but only one expander should mark the response as the primary response.
+
+Each node has an ID and IDs should be unique (to support the `--navigate` command), and typically are the resource ID for the resource in Azure (this allows the `open in portal` action to function)
+
+## APISets
+
+The `SwaggerResourceExpander` is used to drill down within resources. It works against `SwaggerAPISet`s which provide the swagger metadata as well as encapsulating access to the the endpoints identified in the metadata.
+
+The default API Set is `SwaggerAPISetARMResources` which is based on code generated at build time via `make swagger-codegen`. The swagger codegen process loads all of the manamgement plane swagger documents published on GitHub and builds a hierarchy based on the URLs. This is then distilled down into a slightly simpler format based around the `ResourceType` struct. Access to the endpoints in `SwaggerAPISetARMResources` is performed by the `armclient` which piggy-backs on the authentication from the Azure CLI.
+
+Other API Sets can be registered and currently containerService and search are two examples. The Azure Search API Set also uses a `ResourceType` hierarchy generated at build time, but it is dynamically registered with the `SwaggerResourceExpander` when the user expands the "Search Service" node (added by the `AzureSearchServiceExpander`). The API Set instance that is registered at that point has the credentials for authenticating to that specific instance of the Azure Search Service.
+
+The pattern for the container Service API Set is similar: a Kubernetes API node is added by the `AzureKubernetesServiceExpander` and when that is expanded the credentials to the Kubernetes cluster are retrieved and passed to an instance of the API Set. One difference is that the `ResourceType`s for the container service API Set are generated at runtime by querying the Kubernetes API (this allows the node expansion to accurately represent the cluster version as well as any other endpoints that are specific to the cluster)
+
+Issuing `PUT`/`DELETE` requests requires the same authentication as `GET` requests so the `SwaggerResourceExpander` also forwards these to the relevant API Set. (The metadata for the node contains the name of the API Set that returned it)
+
+## Key bindings
+
+Key bindings are initialised in the `setupViewsAndKeybindings` function in `main.go`. Each binding is registered via the `keybindings.AddHandler` function and subsequently bound through the `keybindings.Bind` function.
+
+Handlers implement the `KeyHandler` interface which specifies an ID, an implementation to invoke, the widget that the binding is scoped to, and the default key.
+
+The `ID` and `DefaultKey` functions are both provided by `KeyHandlerBase`. `ID` simply returns the `id` property, and `DefaultKey` performs a lookup in `DefaultKeys` using the ID.

--- a/cmd/azbrowse/cmd.go
+++ b/cmd/azbrowse/cmd.go
@@ -25,7 +25,7 @@ func handleRunCmd(settings *Settings, demo *bool, debug *bool, navigateResource 
 		settings.NavigateToID = *navigateResource
 	}
 
-	if fuzzerDurationMinutes != nil {
+	if fuzzerDurationMinutes != nil && *fuzzerDurationMinutes > 0 {
 		settings.FuzzerEnabled = true
 		settings.FuzzerDurationMinutes = *fuzzerDurationMinutes
 	}
@@ -56,7 +56,7 @@ func handleCommandAndArgs() {
 	runDemo := runCmd.Bool("demo", false, "run in demo mode to filter sensitive output")
 	runDebug := runCmd.Bool("debug", false, "run in debug mode")
 	runNavigate := runCmd.String("navigate", "", "navigate to resource")
-	runFuzzer := runCmd.Int("fuzzer", 15, "run fuzzer (optionally specify the duration in minutes)")
+	runFuzzer := runCmd.Int("fuzzer", -1, "run fuzzer (optionally specify the duration in minutes)")
 
 	if len(os.Args) < 2 {
 		if err := runCmd.Parse(os.Args[1:]); err != nil {

--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"time"
 
@@ -182,7 +183,27 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *Setti
 	content := views.NewItemWidget(leftColumnWidth+2, 1, maxX-leftColumnWidth-1, maxY-4, settings.HideGuids, "")
 	list := views.NewListWidget(ctx, 1, 1, leftColumnWidth, maxY-4, []string{"Loading..."}, 0, content, status, settings.EnableTracing, "Subscriptions", g)
 	notifications := views.NewNotificationWidget(maxX-45, 1, 45, settings.HideGuids, g, client)
-	commandPanel := views.NewCommandPanelWidget(leftColumnWidth+8, 5, maxX-leftColumnWidth-20, g)
+
+	commandPanel := views.NewCommandPanelWidget(leftColumnWidth+3, 0, maxX-leftColumnWidth-20, g)
+
+	commandPanelFilterCommand := keybindings.NewCommandPanelFilterHandler(commandPanel, list)
+	copyCommand := keybindings.NewCopyHandler(content, status)
+	commandPanelAzureSearchQueryCommand := keybindings.NewCommandPanelAzureSearchQueryHandler(commandPanel, content, list)
+	listActionsCommand := keybindings.NewListActionsHandler(list, ctx)
+	listOpenCommand := keybindings.NewListOpenHandler(list, ctx)
+	listUpdateCommand := keybindings.NewListUpdateHandler(list, status, ctx, content, g)
+	listCopyItemIDCommand := keybindings.NewListCopyItemIDHandler(list, status)
+
+	commands := []keybindings.Command{
+		commandPanelFilterCommand,
+		copyCommand,
+		commandPanelAzureSearchQueryCommand,
+		listActionsCommand,
+		listOpenCommand,
+		listUpdateCommand,
+		listCopyItemIDCommand,
+	}
+	sort.Sort(keybindings.SortByDisplayText(commands))
 
 	g.SetManager(status, content, list, notifications, commandPanel)
 	g.SetCurrentView("listWidget")
@@ -195,14 +216,17 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *Setti
 	// NOTE> Global handlers must be registered first to
 	//       ensure double key registration is prevented
 	keybindings.AddHandler(keybindings.NewFullscreenHandler(list, content, &isFullscreen))
-	keybindings.AddHandler(keybindings.NewCopyHandler(content, status))
+	keybindings.AddHandler(copyCommand)
 	keybindings.AddHandler(keybindings.NewHelpHandler(&showHelp))
 	keybindings.AddHandler(keybindings.NewQuitHandler())
 	keybindings.AddHandler(keybindings.NewConfirmDeleteHandler(notifications))
 	keybindings.AddHandler(keybindings.NewClearPendingDeleteHandler(notifications))
-	keybindings.AddHandler(keybindings.NewOpenCommandPanelHandler(commandPanel))
-	keybindings.AddHandler(keybindings.NewCommandPanelFilterHandler(commandPanel))
+	keybindings.AddHandler(keybindings.NewOpenCommandPanelHandler(g, commandPanel, commands))
+	keybindings.AddHandler(commandPanelFilterCommand)
 	keybindings.AddHandler(keybindings.NewCloseCommandPanelHandler(commandPanel))
+	keybindings.AddHandler(keybindings.NewCommandPanelDownHandler(commandPanel))
+	keybindings.AddHandler(keybindings.NewCommandPanelUpHandler(commandPanel))
+	keybindings.AddHandler(keybindings.NewCommandPanelEnterHandler(commandPanel))
 
 	// List handlers
 	keybindings.AddHandler(keybindings.NewListDownHandler(list))
@@ -211,18 +235,19 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *Setti
 	keybindings.AddHandler(keybindings.NewListRefreshHandler(list))
 	keybindings.AddHandler(keybindings.NewListBackHandler(list))
 	keybindings.AddHandler(keybindings.NewListBackLegacyHandler(list))
-	keybindings.AddHandler(keybindings.NewListActionsHandler(list, ctx))
+	keybindings.AddHandler(listActionsCommand)
 	keybindings.AddHandler(keybindings.NewListRightHandler(list, &editModeEnabled))
 	keybindings.AddHandler(keybindings.NewListEditHandler(list, &editModeEnabled))
-	keybindings.AddHandler(keybindings.NewListOpenHandler(list, ctx))
+	keybindings.AddHandler(listOpenCommand)
 	keybindings.AddHandler(keybindings.NewListDeleteHandler(list, notifications))
-	keybindings.AddHandler(keybindings.NewListUpdateHandler(list, status, ctx, content, g))
+	keybindings.AddHandler(listUpdateCommand)
 	keybindings.AddHandler(keybindings.NewListPageDownHandler(list))
 	keybindings.AddHandler(keybindings.NewListPageUpHandler(list))
 	keybindings.AddHandler(keybindings.NewListEndHandler(list))
 	keybindings.AddHandler(keybindings.NewListHomeHandler(list))
 	keybindings.AddHandler(keybindings.NewListClearFilterHandler(list))
-	keybindings.AddHandler(keybindings.NewCommandPanelAzureSearchQueryHandler(commandPanel, content, list))
+	keybindings.AddHandler(commandPanelAzureSearchQueryCommand)
+	keybindings.AddHandler(listCopyItemIDCommand)
 
 	// ItemView handlers
 	keybindings.AddHandler(keybindings.NewItemViewPageDownHandler(content))

--- a/internal/pkg/expanders/action.go
+++ b/internal/pkg/expanders/action.go
@@ -10,6 +10,7 @@ import (
 
 // ActionExpander handles actions
 type ActionExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/activitylog.go
+++ b/internal/pkg/expanders/activitylog.go
@@ -12,6 +12,7 @@ import (
 
 // ActivityLogExpander expands activity logs under an RG
 type ActivityLogExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/appInsights.go
+++ b/internal/pkg/expanders/appInsights.go
@@ -25,6 +25,7 @@ var _ Expander = &AppInsightsExpander{}
 
 // AppInsightsExpander expands aspects of App Insights that don't naturally flow from the api spec
 type AppInsightsExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/containerInstance.go
+++ b/internal/pkg/expanders/containerInstance.go
@@ -20,6 +20,7 @@ var _ Expander = &ContainerInstanceExpander{}
 
 // ContainerInstanceExpander expands the data-plane aspects of a Container Instance
 type ContainerInstanceExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/containerRegistry.go
+++ b/internal/pkg/expanders/containerRegistry.go
@@ -36,6 +36,7 @@ func (e *ContainerRegistryExpander) setClient(c *armclient.Client) {
 
 // ContainerRegistryExpander expands Tthe data-plane aspects of a Container Registry
 type ContainerRegistryExpander struct {
+	ExpanderBase
 	client    *http.Client
 	armClient *armclient.Client
 }
@@ -112,6 +113,19 @@ func (e *ContainerRegistryExpander) Expand(ctx context.Context, currentItem *Tre
 	}
 }
 
+// Delete attempts to delete the item. Returns true if deleted, false if not handled, an error if an error occurred attempting to delete
+func (e *ContainerRegistryExpander) Delete(ctx context.Context, currentItem *TreeNode) (bool, error) {
+	switch currentItem.ItemType {
+	case "containerRegistry.repository":
+		return e.deleteRepository(ctx, currentItem)
+	case "containerRegistry.repository.tag":
+		return e.deleteRepositoryTag(ctx, currentItem)
+	case "containerRegistry.repository.manifest":
+		return e.deleteRepositoryManifest(ctx, currentItem)
+	}
+	return false, nil
+}
+
 func (e *ContainerRegistryExpander) expandRepositories(ctx context.Context, currentItem *TreeNode) ExpanderResult {
 	registryID := currentItem.Metadata["RegistryID"]
 
@@ -140,6 +154,7 @@ func (e *ContainerRegistryExpander) expandRepositories(ctx context.Context, curr
 				Display:   item,
 				ItemType:  "containerRegistry.repository",
 				ExpandURL: ExpandURLNotSupported,
+				DeleteURL: currentItem.ID + "/" + item,
 				Metadata: map[string]string{
 					"loginServer": loginServer,
 					"repository":  item,
@@ -177,7 +192,7 @@ func (e *ContainerRegistryExpander) expandRepository(ctx context.Context, curren
 		}
 	}
 
-	responseBuf, err := e.doRequest(ctx, fmt.Sprintf("https://%s/acr/v1/%s", loginServer, repository), accessToken)
+	responseBuf, err := e.doRequest(ctx, "GET", fmt.Sprintf("https://%s/acr/v1/%s", loginServer, repository), accessToken)
 	if err != nil {
 		return ExpanderResult{
 			Err:               err,
@@ -198,6 +213,21 @@ func (e *ContainerRegistryExpander) expandRepository(ctx context.Context, curren
 		Nodes:             newItems,
 		IsPrimaryResponse: true,
 	}
+}
+func (e *ContainerRegistryExpander) deleteRepository(ctx context.Context, currentItem *TreeNode) (bool, error) {
+	loginServer := currentItem.Metadata["loginServer"]
+	repository := currentItem.Metadata["repository"]
+
+	accessToken, err := e.getRegistryToken(ctx, loginServer, fmt.Sprintf("repository:%s:delete", repository))
+	if err != nil {
+		return false, err
+	}
+
+	_, err = e.doRequest(ctx, "DELETE", fmt.Sprintf("https://%s/acr/v1/%s", loginServer, repository), accessToken)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (e *ContainerRegistryExpander) expandRepositoryTags(ctx context.Context, currentItem *TreeNode) ExpanderResult {
@@ -228,7 +258,7 @@ func (e *ContainerRegistryExpander) expandRepositoryTag(ctx context.Context, cur
 		}
 	}
 
-	responseBuf, err := e.doRequest(ctx, fmt.Sprintf("https://%s/acr/v1/%s/_tags/%s", loginServer, repository, tag), accessToken)
+	responseBuf, err := e.doRequest(ctx, "GET", fmt.Sprintf("https://%s/acr/v1/%s/_tags/%s", loginServer, repository, tag), accessToken)
 	if err != nil {
 		return ExpanderResult{
 			Err:               err,
@@ -259,6 +289,22 @@ func (e *ContainerRegistryExpander) expandRepositoryTag(ctx context.Context, cur
 		IsPrimaryResponse: true,
 	}
 }
+func (e *ContainerRegistryExpander) deleteRepositoryTag(ctx context.Context, currentItem *TreeNode) (bool, error) {
+	loginServer := currentItem.Metadata["loginServer"]
+	repository := currentItem.Metadata["repository"]
+	tag := currentItem.Metadata["tag"]
+
+	accessToken, err := e.getRegistryToken(ctx, loginServer, fmt.Sprintf("repository:%s:delete", repository))
+	if err != nil {
+		return false, err
+	}
+
+	_, err = e.doRequest(ctx, "DELETE", fmt.Sprintf("https://%s/acr/v1/%s/_tags/%s", loginServer, repository, tag), accessToken)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
 
 func (e *ContainerRegistryExpander) expandRepositoryManifests(ctx context.Context, currentItem *TreeNode) ExpanderResult {
 	loginServer := currentItem.Metadata["loginServer"]
@@ -283,12 +329,30 @@ func (e *ContainerRegistryExpander) expandRepositoryManifest(ctx context.Context
 	return e.expandNode(
 		ctx,
 		currentItem,
-		fmt.Sprintf("https://%s/acr/v1/%s/_manifests/%s", loginServer, repository, digest),
+		fmt.Sprintf("https://%s/v2/%s/manifests/%s", loginServer, repository, digest),
 		fmt.Sprintf("repository:%s:metadata_read", repository),
 		"manifest.tags",
 		"",
 		e.getCreateTagNodeFunc(loginServer, repository),
 		nil)
+}
+func (e *ContainerRegistryExpander) deleteRepositoryManifest(ctx context.Context, currentItem *TreeNode) (bool, error) {
+
+	loginServer := currentItem.Metadata["loginServer"]
+	repository := currentItem.Metadata["repository"]
+	digest := currentItem.Metadata["digest"]
+
+	accessToken, err := e.getRegistryToken(ctx, loginServer, fmt.Sprintf("repository:%s:delete", repository))
+	if err != nil {
+		return false, err
+	}
+
+	_, err = e.doRequest(ctx, "DELETE", fmt.Sprintf("https://%s/v2/%s/manifests/%s", loginServer, repository, digest), accessToken)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+
 }
 
 type createItemNode func(currentItem *TreeNode, item string) *TreeNode
@@ -303,6 +367,7 @@ func (e *ContainerRegistryExpander) getCreateManifestNodeFunc(loginServer string
 			Display:   item,
 			ItemType:  "containerRegistry.repository.manifest",
 			ExpandURL: ExpandURLNotSupported,
+			DeleteURL: currentItem.ID + "/" + item,
 			Metadata: map[string]string{
 				"loginServer": loginServer,
 				"repository":  repository,
@@ -322,6 +387,7 @@ func (e *ContainerRegistryExpander) getCreateTagNodeFunc(loginServer string, rep
 			Display:   item,
 			ItemType:  "containerRegistry.repository.tag",
 			ExpandURL: ExpandURLNotSupported,
+			DeleteURL: currentItem.ID + "/" + item,
 			Metadata: map[string]string{
 				"loginServer": loginServer,
 				"repository":  repository,
@@ -440,7 +506,7 @@ func (e *ContainerRegistryExpander) getItemsForURL(ctx context.Context, url stri
 	span, ctx := tracing.StartSpanFromContext(ctx, "getItemsForURL(containerregistry):"+url, tracing.SetTag("url", url))
 	defer span.Finish()
 
-	responseBuf, err := e.doRequest(ctx, url, accessToken)
+	responseBuf, err := e.doRequest(ctx, "GET", url, accessToken)
 	if err != nil {
 		return "", []string{}, err
 	}
@@ -482,11 +548,11 @@ func (e *ContainerRegistryExpander) getItemsForURL(ctx context.Context, url stri
 	return response, itemsResult, nil
 }
 
-func (e *ContainerRegistryExpander) doRequest(ctx context.Context, url string, accessToken string) ([]byte, error) {
+func (e *ContainerRegistryExpander) doRequest(ctx context.Context, verb string, url string, accessToken string) ([]byte, error) {
 	span, _ := tracing.StartSpanFromContext(ctx, "doRequest(containerregistry):"+url, tracing.SetTag("url", url))
 	defer span.Finish()
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(verb, url, nil)
 	if err != nil {
 		return []byte{}, fmt.Errorf("Failed to create request: %s", err)
 	}
@@ -497,7 +563,7 @@ func (e *ContainerRegistryExpander) doRequest(ctx context.Context, url string, a
 		return []byte{}, fmt.Errorf("Request failed: %s", err)
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return []byte{}, fmt.Errorf("DoRequest failed %v for '%s'", response.StatusCode, url)
 	}
 

--- a/internal/pkg/expanders/containerService.go
+++ b/internal/pkg/expanders/containerService.go
@@ -54,6 +54,7 @@ var _ Expander = &AzureKubernetesServiceExpander{}
 
 // AzureKubernetesServiceExpander expands the kubernetes aspects of AKS
 type AzureKubernetesServiceExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/default.go
+++ b/internal/pkg/expanders/default.go
@@ -19,15 +19,13 @@ var _ Expander = &DefaultExpander{}
 
 // DefaultExpander expands RGs under a subscription
 type DefaultExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 
 func (e *DefaultExpander) setClient(c *armclient.Client) {
 	e.client = c
 }
-
-// DefaultExpanderInstance provides an instance of the default expander for use
-var DefaultExpanderInstance DefaultExpander
 
 // Name returns the name of the expander
 func (e *DefaultExpander) Name() string {

--- a/internal/pkg/expanders/deployments.go
+++ b/internal/pkg/expanders/deployments.go
@@ -13,6 +13,7 @@ var _ Expander = &DeploymentsExpander{}
 
 // DeploymentsExpander expands RGs under a subscription
 type DeploymentsExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/expander.go
+++ b/internal/pkg/expanders/expander.go
@@ -108,9 +108,9 @@ func ExpandItem(ctx context.Context, currentItem *TreeNode) (*ExpanderResponse, 
 	}
 
 	// Use the default handler to get the resource JSON for display
-	defaultExpanderWorksOnThisItem, _ := DefaultExpanderInstance.DoesExpand(ctx, currentItem)
+	defaultExpanderWorksOnThisItem, _ := GetDefaultExpander().DoesExpand(ctx, currentItem)
 	if !hasPrimaryResponse && defaultExpanderWorksOnThisItem {
-		result := DefaultExpanderInstance.Expand(ctx, currentItem)
+		result := GetDefaultExpander().Expand(ctx, currentItem)
 		if result.Err != nil {
 			eventing.SendStatusEvent(eventing.StatusEvent{
 				InProgress: true,

--- a/internal/pkg/expanders/json.go
+++ b/internal/pkg/expanders/json.go
@@ -10,7 +10,9 @@ import (
 var _ Expander = &JSONExpander{}
 
 // JSONExpander expands an item with "jsonItem" in its metadata
-type JSONExpander struct{}
+type JSONExpander struct {
+	ExpanderBase
+}
 
 func (e *JSONExpander) setClient(c *armclient.Client) {
 	// noop

--- a/internal/pkg/expanders/metrics.go
+++ b/internal/pkg/expanders/metrics.go
@@ -29,6 +29,7 @@ var _ Expander = &MetricsExpander{}
 
 // MetricsExpander expands the data-plane aspects of the Microsoft.Insights RP
 type MetricsExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/registerExpanders.go
+++ b/internal/pkg/expanders/registerExpanders.go
@@ -5,10 +5,16 @@ import (
 )
 
 var swaggerResourceExpander *SwaggerResourceExpander
+var defaultExpander *DefaultExpander
 
 // GetSwaggerResourceExpander returns the (singleton) instance of SwaggerResourceExpander
 func GetSwaggerResourceExpander() *SwaggerResourceExpander {
 	return swaggerResourceExpander
+}
+
+// GetDefaultExpander returns the (singleton) instance of DefaultExpander
+func GetDefaultExpander() *DefaultExpander {
+	return defaultExpander
 }
 
 // register tracks all the current handlers
@@ -21,6 +27,10 @@ var register []Expander
 func InitializeExpanders(client *armclient.Client) {
 	swaggerResourceExpander = NewSwaggerResourcesExpander()
 	swaggerResourceExpander.AddAPISet(NewSwaggerAPISetARMResources(client))
+
+	defaultExpander = &DefaultExpander{
+		client: client,
+	}
 
 	register = []Expander{
 		&TenantExpander{

--- a/internal/pkg/expanders/resourcegroup.go
+++ b/internal/pkg/expanders/resourcegroup.go
@@ -23,6 +23,7 @@ var _ Expander = &ResourceGroupResourceExpander{}
 
 // ResourceGroupResourceExpander expands resource under an RG
 type ResourceGroupResourceExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/search.go
+++ b/internal/pkg/expanders/search.go
@@ -20,6 +20,7 @@ type adminKeysResponse struct {
 
 // AzureSearchServiceExpander expands the kubernetes aspects of AKS
 type AzureSearchServiceExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/storageManagementPolicies.go
+++ b/internal/pkg/expanders/storageManagementPolicies.go
@@ -16,7 +16,9 @@ import (
 var _ Expander = &StorageManagementPoliciesExpander{}
 
 // StorageManagementPoliciesExpander expands The default management policy under a storage account
-type StorageManagementPoliciesExpander struct{}
+type StorageManagementPoliciesExpander struct {
+	ExpanderBase
+}
 
 func (e *StorageManagementPoliciesExpander) setClient(c *armclient.Client) {
 	// noop

--- a/internal/pkg/expanders/subscription.go
+++ b/internal/pkg/expanders/subscription.go
@@ -14,6 +14,7 @@ var _ Expander = &SubscriptionExpander{}
 
 // SubscriptionExpander expands RGs under a subscription
 type SubscriptionExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/swagger.go
+++ b/internal/pkg/expanders/swagger.go
@@ -45,6 +45,7 @@ type APISetExpandResponse struct {
 
 // SwaggerResourceExpander expands resource under an AppService
 type SwaggerResourceExpander struct {
+	ExpanderBase
 	apiSets map[string]*SwaggerAPISet
 }
 

--- a/internal/pkg/expanders/tentant.go
+++ b/internal/pkg/expanders/tentant.go
@@ -21,6 +21,7 @@ var _ Expander = &TenantExpander{}
 
 // TenantExpander expands the subscriptions under a tenant
 type TenantExpander struct {
+	ExpanderBase
 	client *armclient.Client
 }
 

--- a/internal/pkg/expanders/types.go
+++ b/internal/pkg/expanders/types.go
@@ -17,10 +17,19 @@ type Expander interface {
 	DoesExpand(ctx context.Context, currentNode *TreeNode) (bool, error)
 	Expand(ctx context.Context, currentNode *TreeNode) ExpanderResult
 	Name() string
+	Delete(context context.Context, item *TreeNode) (bool, error)
 
 	// Used for testing the expanders
 	testCases() (bool, *[]expanderTestCase)
 	setClient(c *armclient.Client)
+}
+
+// ExpanderBase provides nil implementations of Expander methods to avoid duplicating code
+type ExpanderBase struct{}
+
+// Delete attempts to delete the item. Returns true if deleted, false if not handled, an error if an error occurred attempting to delete
+func (e *ExpanderBase) Delete(context context.Context, item *TreeNode) (bool, error) {
+	return false, nil
 }
 
 // ExpanderResponseType is used to indicate the text format of a response

--- a/internal/pkg/keybindings/bindings.go
+++ b/internal/pkg/keybindings/bindings.go
@@ -57,7 +57,9 @@ func GetKeyBindingsAsStrings() map[string][]string {
 	for k, values := range keys {
 		stringValues := []string{}
 		for _, v := range values {
-			stringValues = append(stringValues, keyToString(v))
+			if v != nil {
+				stringValues = append(stringValues, keyToString(v))
+			}
 		}
 		keyBindings[k] = stringValues
 	}
@@ -84,6 +86,9 @@ func bindHandlerToKey(g *gocui.Gui, hnd KeyHandler) error {
 	}
 
 	for _, key := range keys {
+		if key == nil {
+			continue
+		}
 		if err := checkKeyNotAlreadyInUse(hnd.Widget(), hnd.ID(), key); err != nil {
 			return err
 		}
@@ -196,12 +201,12 @@ func cleanValue(str string) string {
 }
 
 func keyToString(key interface{}) string {
-	switch key.(type) { //nolint: gosimple
+	switch t := key.(type) { //nolint: gosimple
 	case gocui.Key:
 		return GocuiKeyToStr[key.(gocui.Key)]
 	case rune:
 		return string(key.(rune))
 	default:
-		panic("Unhandled key type\n")
+		panic(fmt.Sprintf("Unhandled key type: %v\n", t))
 	}
 }

--- a/internal/pkg/keybindings/commandpanelhandlers.go
+++ b/internal/pkg/keybindings/commandpanelhandlers.go
@@ -20,7 +20,79 @@ func NewCloseCommandPanelHandler(commandPanelWidget *views.CommandPanelWidget) *
 
 func (h *CloseCommandPanelHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
 	return func(g *gocui.Gui, v *gocui.View) error {
-		h.commandPanelWidget.ToggleShowHide()
+		h.commandPanelWidget.Hide()
+		return nil
+	}
+}
+
+////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////
+
+type CommandPanelDownHandler struct {
+	CommandPanelHandler
+	commandPanelWidget *views.CommandPanelWidget
+}
+
+func NewCommandPanelDownHandler(commandPanelWidget *views.CommandPanelWidget) *CommandPanelDownHandler {
+	handler := &CommandPanelDownHandler{
+		commandPanelWidget: commandPanelWidget,
+	}
+	handler.id = HandlerIDCommandPanelDown
+	return handler
+}
+
+func (h *CommandPanelDownHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		h.commandPanelWidget.MoveDown()
+		return nil
+	}
+}
+
+////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////
+
+type CommandPanelUpHandler struct {
+	CommandPanelHandler
+	commandPanelWidget *views.CommandPanelWidget
+}
+
+func NewCommandPanelUpHandler(commandPanelWidget *views.CommandPanelWidget) *CommandPanelUpHandler {
+	handler := &CommandPanelUpHandler{
+		commandPanelWidget: commandPanelWidget,
+	}
+	handler.id = HandlerIDCommandPanelUp
+	return handler
+}
+
+func (h *CommandPanelUpHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		h.commandPanelWidget.MoveUp()
+		return nil
+	}
+}
+
+////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////
+
+type CommandPanelEnterHandler struct {
+	CommandPanelHandler
+	commandPanelWidget *views.CommandPanelWidget
+}
+
+func NewCommandPanelEnterHandler(commandPanelWidget *views.CommandPanelWidget) *CommandPanelEnterHandler {
+	handler := &CommandPanelEnterHandler{
+		commandPanelWidget: commandPanelWidget,
+	}
+	handler.id = HandlerIDCommandPanelEnter
+	return handler
+}
+
+func (h *CommandPanelEnterHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		h.commandPanelWidget.EnterPressed()
 		return nil
 	}
 }

--- a/internal/pkg/keybindings/defaults.go
+++ b/internal/pkg/keybindings/defaults.go
@@ -34,7 +34,10 @@ var DefaultKeys = map[string]interface{}{
 	"itempagedown":        gocui.KeyPgdn,
 	"itempageup":          gocui.KeyPgup,
 	"commandpanelopen":    gocui.KeyCtrlP,
-	"filter":              rune("/"[0]),
+	"commandpaneldown":    gocui.KeyArrowDown,
+	"commandpanelup":      gocui.KeyArrowUp,
+	"commandpanelenter":   gocui.KeyEnter,
+	"filter":              rune('/'),
 	"commandpanelclose":   gocui.KeyEsc,
 	"azuresearchquery":    gocui.KeyCtrlR,
 }

--- a/internal/pkg/keybindings/keyhandlers.go
+++ b/internal/pkg/keybindings/keyhandlers.go
@@ -29,12 +29,16 @@ const (
 	HandlerIDListEnd                 HandlerID = "listend"             //nolint:golint
 	HandlerIDListHome                HandlerID = "listhome"            //nolint:golint
 	HandlerIDListClearFilter         HandlerID = "listclearfilter"     //nolint:golint
+	HandlerIDListCopyItemID          HandlerID = "listcopyitemid"      //nolint:golint
 	HandlerIDConfirmDelete           HandlerID = "confirmdelete"       //nolint:golint
 	HandlerIDClearPendingDeletes     HandlerID = "clearpendingdeletes" //nolint:golint
 	HandlerIDItemPageDown            HandlerID = "itempagedown"        //nolint:golint
 	HandlerIDItemPageUp              HandlerID = "itempageup"          //nolint:golint
 	HandlerIDToggleOpenCommandPanel  HandlerID = "commandpanelopen"    //nolint:golint
 	HandlerIDToggleCloseCommandPanel HandlerID = "commandpanelclose"   //nolint:golint
+	HandlerIDCommandPanelDown        HandlerID = "commandpaneldown"    //nolint:golint
+	HandlerIDCommandPanelUp          HandlerID = "commandpanelup"      //nolint:golint
+	HandlerIDCommandPanelEnter       HandlerID = "commandpanelenter"   //nolint:golint
 	HandlerIDFilter                  HandlerID = "filter"              //nolint:golint
 	HandlerIDAzureSearchQuery        HandlerID = "azuresearchquery"    //nolist:golint
 )

--- a/internal/pkg/keybindings/types.go
+++ b/internal/pkg/keybindings/types.go
@@ -1,0 +1,26 @@
+package keybindings
+
+import (
+	"strings"
+)
+
+// Command represents a command that can be listed in the Command Palette
+type Command interface {
+	ID() string
+	DisplayText() string
+	IsEnabled() bool
+	Invoke() error
+}
+
+// SortByDisplayText allows sorting an array of Commands by DisplayText
+type SortByDisplayText []Command
+
+func (s SortByDisplayText) Len() int {
+	return len(s)
+}
+func (s SortByDisplayText) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s SortByDisplayText) Less(i, j int) bool {
+	return strings.Compare(s[i].DisplayText(), s[j].DisplayText()) < 0
+}

--- a/internal/pkg/keybindings/utils.go
+++ b/internal/pkg/keybindings/utils.go
@@ -1,5 +1,20 @@
 package keybindings
 
+import (
+	"github.com/atotto/clipboard"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/wsl"
+)
+
 func toggle(b bool) bool {
 	return !b
+}
+
+func copyToClipboard(content string) error {
+	var err error
+	if wsl.IsWSL() {
+		err = wsl.TrySetClipboard(content)
+	} else {
+		err = clipboard.WriteAll(content)
+	}
+	return err
 }

--- a/internal/pkg/storage/store.go
+++ b/internal/pkg/storage/store.go
@@ -6,18 +6,29 @@ import (
 	"github.com/boltdb/bolt"
 	"log"
 	"os/user"
+	"time"
 )
 
 var db *bolt.DB
 
 func init() {
-	fmt.Println("AzBrowse is waiting for access to '~/.azbrowse.db', do you have another instance of azbrowse open?")
+	fmt.Println("Loading db ...")
 	dbLocation := "/root/.azbrowse.db"
 	user, err := user.Current()
 	if err == nil {
 		dbLocation = user.HomeDir + "/.azbrowse.db"
 	}
+
+	suppressWaitingMessage := false
+	go func() {
+		time.Sleep(2 * time.Second)
+		if !suppressWaitingMessage {
+			fmt.Println("AzBrowse is waiting for access to '~/.azbrowse.db', do you have another instance of azbrowse open?")
+		}
+	}()
+
 	dbCreate, err := bolt.Open(dbLocation, 0600, nil)
+	suppressWaitingMessage = true
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/pkg/views/actions.go
+++ b/internal/pkg/views/actions.go
@@ -25,6 +25,9 @@ func LoadActionsView(ctx context.Context, list *ListWidget) error {
 	}
 
 	currentExpandedItem := list.CurrentExpandedItem()
+	if currentExpandedItem == nil {
+		return nil
+	}
 	if currentExpandedItem.ItemType == expanders.ResourceType {
 		namespace = currentExpandedItem.Namespace
 		armType = currentExpandedItem.ArmType

--- a/internal/pkg/views/commandpanel.go
+++ b/internal/pkg/views/commandpanel.go
@@ -1,23 +1,45 @@
 package views
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/stuartleeks/gocui"
 )
 
+// CommandPanelListOption represents a list item that can be displayed in the CommandPanel
+type CommandPanelListOption struct {
+	ID          string
+	DisplayText string
+}
+
+// CommandPanelNotification holds the event state for a panel changed notification
+type CommandPanelNotification struct {
+	CurrentText  string
+	SelectedID   string
+	EnterPressed bool
+}
+
+// CommandPanelNotificationHandler is the function signature for a panel changed notification handler
+type CommandPanelNotificationHandler func(state CommandPanelNotification)
+
 // CommandPanelWidget controls the notifications windows in the top right
 type CommandPanelWidget struct {
-	name             string
-	x, y             int
-	w                int
-	visible          bool
-	gui              *gocui.Gui
-	panelContent     string
-	newPanelContent  string
-	prepopulate      string
-	previousViewName string
+	name                string
+	x, y                int
+	w                   int
+	visible             bool
+	gui                 *gocui.Gui
+	panelContent        string
+	newPanelContent     string
+	prepopulate         string
+	previousViewName    string
+	title               string
+	options             *[]CommandPanelListOption
+	filteredOptions     *[]CommandPanelListOption
+	selectedIndex       int
+	notificationHandler CommandPanelNotificationHandler
+	lastTopIndex        int
 }
 
 // NewCommandPanelWidget create new instance and start go routine for spinner
@@ -33,27 +55,59 @@ func NewCommandPanelWidget(x, y, w int, g *gocui.Gui) *CommandPanelWidget {
 	return widget
 }
 
-// ToggleShowHide shows and hides the command panel
-func (w *CommandPanelWidget) ToggleShowHide() {
-	// Ensure we put things back how we found them before the panel was launched
-	if !w.visible {
-		w.trackPreviousView()
-	}
-
-	// Show or hide
+// Hide hides the command panel
+func (w *CommandPanelWidget) Hide() {
+	// hide
 	w.prepopulate = ""
-	w.visible = !w.visible
+	w.visible = false
 }
 
 // ShowWithText launches the command panel pre-populated with some text
-func (w *CommandPanelWidget) ShowWithText(s string) {
+func (w *CommandPanelWidget) ShowWithText(title string, s string, options *[]CommandPanelListOption, handler CommandPanelNotificationHandler) {
 	// Ensure we put things back how we found them before the panel was launched
 	w.trackPreviousView()
 
 	w.gui.DeleteView(w.name) //nolint: errcheck
+	w.title = title
 	w.gui.Cursor = false
 	w.prepopulate = s
+	w.options = options
+	w.filteredOptions = options
+	w.notificationHandler = handler
 	w.visible = true
+	w.selectedIndex = -1
+	w.lastTopIndex = 0
+}
+
+// MoveDown moves down a list item if options are displayed
+func (w *CommandPanelWidget) MoveDown() {
+	if w.filteredOptions != nil && len(*w.filteredOptions) > 0 {
+		w.selectedIndex++
+		if w.selectedIndex >= len(*w.filteredOptions) {
+			w.selectedIndex = len(*w.filteredOptions) - 1
+		}
+	}
+}
+
+// MoveUp moves up a list item if options are displayed
+func (w *CommandPanelWidget) MoveUp() {
+	if w.filteredOptions != nil && len(*w.filteredOptions) > 0 {
+		w.selectedIndex--
+		if w.selectedIndex < 0 {
+			w.selectedIndex = 0
+		}
+	}
+}
+
+// Width returns the width of the CommandPanel
+func (w *CommandPanelWidget) Width() int {
+	return w.w
+}
+
+// EnterPressed is used to communicate that the enter key was pressed but a handler received it
+func (w *CommandPanelWidget) EnterPressed() {
+	// the handler was added to invoke this method as Enter without any input failed to trigger the update
+	w.panelChanged(w.panelContent + "\n\n") // ensure newlines to trigger EnterPressed logic
 }
 
 func (w *CommandPanelWidget) trackPreviousView() {
@@ -64,44 +118,108 @@ func (w *CommandPanelWidget) trackPreviousView() {
 
 // Layout draws the widget in the gocui view
 func (w *CommandPanelWidget) Layout(g *gocui.Gui) error {
+
+	inputViewName := w.name
+	optionsViewName := w.name + "Options"
+	listHeight := 10
+
 	// If we're not updating an existing view then
 	// set the content to the value from prepopulate
 	viewExists := true
-	_, err := g.View(w.name)
+	_, err := g.View(inputViewName)
 	if err == gocui.ErrUnknownView {
 		viewExists = false
 	}
 
-	// If we have a view but we're not meant to clean up
-	if viewExists && !w.visible {
-		g.DeleteView(w.name)
-		g.SetCurrentView(w.previousViewName) //nolint: errcheck
-		g.Cursor = false
+	// If we're not visible then do any clean-up needed
+	if !w.visible {
+		if _, err := g.View(optionsViewName); err != gocui.ErrUnknownView {
+			g.DeleteView(optionsViewName)
+		}
+		if viewExists {
+			g.DeleteView(inputViewName)
+			g.SetCurrentView(w.previousViewName) //nolint: errcheck
+			g.Cursor = false
+		}
 		return nil
 	}
 
-	// If the view doesn't exists and we're not visible do nothing
-	if !w.visible {
-		return nil
+	if w.options == nil {
+		// delete options view if now options
+		if _, err := g.View(optionsViewName); err != gocui.ErrUnknownView {
+			g.DeleteView(optionsViewName)
+		}
 	}
 
 	height := 2
 
-	v, err := g.SetView(w.name, w.x, w.y, w.x+w.w, w.y+height)
+	var vList *gocui.View
+	if w.options != nil {
+		vList, err = g.SetView(optionsViewName, w.x, w.y+2, w.x+w.w, w.y+3+listHeight)
+		if err != nil && err != gocui.ErrUnknownView {
+			return err
+		}
+	}
+
+	v, err := g.SetView(inputViewName, w.x, w.y, w.x+w.w, w.y+height)
 	if err != nil && err != gocui.ErrUnknownView {
 		return err
 	}
 
 	v.Editable = true
 	g.Cursor = true
-	v.Title = "Command Panel"
+	v.Title = w.title
 	v.Wrap = false
+
+	if w.options != nil {
+		vList.Clear()
+		renderedItems := []string{}
+
+		for i, option := range *w.filteredOptions {
+			itemToShow := ""
+			if i == w.selectedIndex {
+				itemToShow = "▶ "
+			} else {
+				itemToShow = "  "
+			}
+			itemToShow += option.DisplayText + "\n"
+			renderedItems = append(renderedItems, itemToShow)
+		}
+		topIndex := w.lastTopIndex
+		bottomIndex := w.lastTopIndex + listHeight
+		if w.selectedIndex >= bottomIndex {
+			// need to adjust down
+			diff := w.selectedIndex - bottomIndex + 1
+			topIndex += diff
+			bottomIndex += diff
+		}
+		if w.selectedIndex >= 0 && w.selectedIndex < topIndex {
+			// need to adjust up
+			diff := topIndex - w.selectedIndex
+			topIndex -= diff
+			bottomIndex -= diff
+		}
+		w.lastTopIndex = topIndex
+		if bottomIndex > len(renderedItems) {
+			bottomIndex = len(renderedItems) - 1
+		}
+
+		for index := topIndex; index < bottomIndex+1; index++ {
+			if index < len(renderedItems) {
+				item := renderedItems[index]
+				fmt.Fprint(vList, item)
+			}
+		}
+
+		// maxItemsCanShow := w.
+	}
 
 	// Is this a new view?
 	if !viewExists {
 		// It is lets prepopulate it with content like `/` if it was launched from the filter handler
 		v.Write([]byte(w.prepopulate))     //nolint: errcheck
 		v.SetCursor(len(w.prepopulate), 0) //nolint: errcheck
+
 	} else if w.newPanelContent != "" {
 		// update panel contents
 		v.Clear()
@@ -120,49 +238,80 @@ func (w *CommandPanelWidget) Layout(g *gocui.Gui) error {
 		// Has something been typed?
 		w.panelContent = v.Buffer()
 		// Handle this change and take action
-		w.panelChanged()
+		w.panelChanged(w.panelContent)
 	}
 
-	_, err = w.gui.SetCurrentView(w.name)
+	_, err = w.gui.SetCurrentView(inputViewName)
 	if err != nil {
-		panic("No view " + w.name + " found: " + err.Error())
+		panic("No view " + inputViewName + " found: " + err.Error())
 	}
 
 	return nil
 }
 
 // This is fired every time the content of the command panel has changed.
-func (w *CommandPanelWidget) panelChanged() {
-	content := w.panelContent
+func (w *CommandPanelWidget) panelChanged(content string) {
 
-	if len(content) < 1 {
+	if len(content) < 1 && w.selectedIndex < 0 {
 		return
 	}
 
-	// What command is being used?
+	state := CommandPanelNotification{
+		EnterPressed: w.contentHasNewLine(content),
+		CurrentText:  strings.ReplaceAll(content, "\n", ""),
+	}
 
-	// `/` -> Filter command
-	if strings.HasPrefix(content, "/") {
-		eventing.Publish("filter", content)
-	} else if strings.HasPrefix(content, "search-query:") {
-		if w.contentHasNewLine() {
-			content = strings.ReplaceAll(content, "\n", "")
-			eventing.Publish("azure-search-query", content)
-			// clear the newlines
-			w.newPanelContent = content
-			if err := w.Layout(w.gui); err != nil {
-				panic("Layout failed")
+	triggerLayout := false
+	// Clear newlines to allow usage with repeated enter presses (e.g. search)
+	if state.EnterPressed {
+		w.newPanelContent = state.CurrentText
+		triggerLayout = true
+	}
+	if w.options != nil {
+		// apply filter, re-selecting the current item
+		selectedID := ""
+		if w.selectedIndex >= 0 && w.selectedIndex < len(*w.filteredOptions) {
+			selectedID = (*w.filteredOptions)[w.selectedIndex].ID
+		}
+		w.selectedIndex = -1
+		filterOptions := []CommandPanelListOption{}
+		loweredCurrentText := strings.ToLower(state.CurrentText)
+		for i, option := range *w.options {
+			if strings.Contains(strings.ToLower(option.DisplayText), loweredCurrentText) {
+				if option.ID == selectedID {
+					w.selectedIndex = i
+				}
+				filterOptions = append(filterOptions, option)
 			}
-			return // prevent falling through to hide panel
+		}
+		w.filteredOptions = &filterOptions
+		triggerLayout = true
+	}
+
+	if state.EnterPressed {
+		if w.filteredOptions != nil {
+			if w.selectedIndex >= 0 && w.selectedIndex < len(*w.filteredOptions) && len(*w.filteredOptions) > 0 {
+				state.SelectedID = (*w.filteredOptions)[w.selectedIndex].ID
+			} else if len(*w.filteredOptions) == 1 {
+				// no selected item but only one left - pretend it was selected
+				state.SelectedID = (*w.filteredOptions)[0].ID
+			}
 		}
 	}
 
-	// Handle return by closing panel... events should handle dealing with whats needed
-	if w.contentHasNewLine() {
-		w.ToggleShowHide()
+	if triggerLayout {
+		if err := w.Layout(w.gui); err != nil {
+			panic("Layout failed")
+		}
 	}
+
+	w.gui.Update(func(gui *gocui.Gui) error {
+		w.notificationHandler(state)
+		return nil
+	})
+
 }
 
-func (w *CommandPanelWidget) contentHasNewLine() bool {
-	return strings.Count(w.panelContent, "\n") > 1 //Warning: By default gocui is adding a newline so we're checking for existence of 2
+func (w *CommandPanelWidget) contentHasNewLine(content string) bool {
+	return strings.Count(content, "\n") > 1 //Warning: By default gocui is adding a newline so we're checking for existence of 2
 }

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -38,28 +38,6 @@ type ListWidget struct {
 // NewListWidget creates a new instance
 func NewListWidget(ctx context.Context, x, y, w, h int, items []string, selected int, contentView *ItemWidget, status *StatusbarWidget, enableTracing bool, title string, g *gocui.Gui) *ListWidget {
 	listWidget := &ListWidget{ctx: ctx, x: x, y: y, w: w, h: h, contentView: contentView, statusView: status, enableTracing: enableTracing, lastTopIndex: 0, filterString: "", title: title, g: g}
-	go func() {
-		filterChannel := eventing.SubscribeToTopic("filter")
-		for {
-			filterStringInterface := <-filterChannel
-			filterString := strings.ToLower(strings.TrimSpace(strings.Replace(filterStringInterface.(string), "/", "", 1)))
-
-			filteredItems := []*expanders.TreeNode{}
-			for _, item := range listWidget.items {
-				if strings.Contains(strings.ToLower(item.Display), filterString) {
-					filteredItems = append(filteredItems, item)
-				}
-			}
-
-			listWidget.selected = 0
-			listWidget.filterString = filterString
-			listWidget.filteredItems = filteredItems
-
-			g.Update(func(gui *gocui.Gui) error {
-				return nil
-			})
-		}
-	}()
 	return listWidget
 }
 
@@ -69,6 +47,24 @@ func (w *ListWidget) itemCount() int {
 	}
 
 	return len(w.filteredItems)
+}
+
+// SetFilter sets the filter to be applied to list items
+func (w *ListWidget) SetFilter(filterString string) {
+	filteredItems := []*expanders.TreeNode{}
+	for _, item := range w.items {
+		if strings.Contains(strings.ToLower(item.Display), filterString) {
+			filteredItems = append(filteredItems, item)
+		}
+	}
+
+	w.selected = 0
+	w.filterString = filterString
+	w.filteredItems = filteredItems
+
+	w.g.Update(func(gui *gocui.Gui) error {
+		return nil
+	})
 }
 
 // ClearFilter clears a filter if applied
@@ -217,17 +213,13 @@ func (w *ListWidget) ExpandCurrentSelection() {
 	}
 
 	currentItem := w.CurrentItem()
-	w.ClearFilter()
 
 	newTitle := fmt.Sprintf("[%s-> Fullscreen|%s -> Actions] %s", strings.ToUpper(w.FullscreenKeyBinding), strings.ToUpper(w.ActionKeyBinding), currentItem.Name)
 
 	newContent, newItems, err := expanders.ExpandItem(w.ctx, currentItem)
-	if err != nil {
-		// Shouldn't be possible
-		panic(err)
+	if err == nil { // expander emits status event on error
+		w.Navigate(newItems, newContent, newTitle)
 	}
-
-	w.Navigate(newItems, newContent, newTitle)
 }
 
 // Navigate updates the currently selected list nodes, title and details content

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -35,6 +35,12 @@ type ListWidget struct {
 	lastTopIndex         int
 }
 
+// ListNavigatedEventState captures the state when raising a `list.navigated` event
+type ListNavigatedEventState struct {
+	Success  bool                  // True if this was a successful navigation
+	NewNodes []*expanders.TreeNode // If Success==true this contains the new nodes
+}
+
 // NewListWidget creates a new instance
 func NewListWidget(ctx context.Context, x, y, w, h int, items []string, selected int, contentView *ItemWidget, status *StatusbarWidget, enableTracing bool, title string, g *gocui.Gui) *ListWidget {
 	listWidget := &ListWidget{ctx: ctx, x: x, y: y, w: w, h: h, contentView: contentView, statusView: status, enableTracing: enableTracing, lastTopIndex: 0, filterString: "", title: title, g: g}
@@ -192,6 +198,7 @@ func (w *ListWidget) GoBack() {
 	}
 	previousPage := w.navStack.Pop()
 	if previousPage == nil {
+		eventing.Publish("list.navigated", ListNavigatedEventState{Success: false})
 		return
 	}
 	w.contentView.SetContent(previousPage.Data, previousPage.DataType, "Response")
@@ -201,7 +208,7 @@ func (w *ListWidget) GoBack() {
 	w.selected = previousPage.Selection
 	w.expandedNodeItem = previousPage.ExpandedNodeItem
 
-	eventing.Publish("list.navigated", w.items)
+	eventing.Publish("list.navigated", ListNavigatedEventState{Success: true, NewNodes: w.items})
 
 }
 
@@ -217,13 +224,21 @@ func (w *ListWidget) ExpandCurrentSelection() {
 	newTitle := fmt.Sprintf("[%s-> Fullscreen|%s -> Actions] %s", strings.ToUpper(w.FullscreenKeyBinding), strings.ToUpper(w.ActionKeyBinding), currentItem.Name)
 
 	newContent, newItems, err := expanders.ExpandItem(w.ctx, currentItem)
-	if err == nil { // expander emits status event on error
-		w.Navigate(newItems, newContent, newTitle)
+	if err != nil { // Don't need to display error as expander emits status event on error
+		// Set parameters to trigger non-successful `list.navigated` event
+		newItems = []*expanders.TreeNode{}
+		newContent = nil
+		newTitle = ""
 	}
+	w.Navigate(newItems, newContent, newTitle)
 }
 
 // Navigate updates the currently selected list nodes, title and details content
 func (w *ListWidget) Navigate(nodes []*expanders.TreeNode, content *expanders.ExpanderResponse, title string) {
+
+	if len(nodes) == 0 && content == nil && title == "" {
+		eventing.Publish("list.navigated", ListNavigatedEventState{Success: false})
+	}
 	currentItem := w.CurrentItem()
 	if len(nodes) > 0 {
 		w.SetNodes(nodes)
@@ -234,7 +249,12 @@ func (w *ListWidget) Navigate(nodes []*expanders.TreeNode, content *expanders.Ex
 		w.title = w.title + ">" + currentItem.Name
 	}
 
-	eventing.Publish("list.navigated", nodes)
+	eventing.Publish("list.navigated", ListNavigatedEventState{Success: true, NewNodes: nodes})
+}
+
+// GetNodes returns the currently listed nodes
+func (w *ListWidget) GetNodes() []*expanders.TreeNode {
+	return w.items
 }
 
 // SetNodes allows others to set the list nodes

--- a/internal/pkg/views/notifications.go
+++ b/internal/pkg/views/notifications.go
@@ -112,11 +112,14 @@ func (w *NotificationWidget) ConfirmDelete() {
 			Timeout:    time.Second * 15,
 		})
 
-		swaggerExpander := expanders.GetSwaggerResourceExpander()
-
 		for _, i := range pending {
-			swaggerDeleted, err := swaggerExpander.Delete(context.Background(), i)
-			if err == nil && !swaggerDeleted {
+			var err error
+			fallback := true
+			if i.Expander != nil {
+				deleted, err := i.Expander.Delete(context.Background(), i)
+				fallback = (err == nil && !deleted)
+			}
+			if fallback {
 				// fallback to ARM request to delete
 				_, err = w.client.DoRequest(context.Background(), "DELETE", i.DeleteURL)
 			}

--- a/internal/pkg/wsl/utils.go
+++ b/internal/pkg/wsl/utils.go
@@ -41,7 +41,19 @@ func TrySetClipboard(text string) error {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("Error running wslpath: %s", stderr.String())
+		return fmt.Errorf("Error running clip.exe: %s", stderr.String())
+	}
+	return nil
+}
+
+// TryLaunchBrowser attempts to launch the browser to the specified URL
+func TryLaunchBrowser(url string) error {
+	cmd := exec.Command("explorer.exe", url)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Error running launching URL: %s", stderr.String())
 	}
 	return nil
 }

--- a/pkg/armclient/armclient.go
+++ b/pkg/armclient/armclient.go
@@ -27,7 +27,7 @@ type Client struct {
 	client   *http.Client
 	tenantID string
 
-	aquireToken TokenFunc
+	acquireToken TokenFunc
 }
 
 // LegacyInstance is a singleton ARMClient used while migrating to the
@@ -37,16 +37,16 @@ var LegacyInstance = NewClientFromCLI()
 // NewClientFromCLI creates a new client using the auth details on disk used by the azurecli
 func NewClientFromCLI() *Client {
 	return &Client{
-		aquireToken: aquireTokenFromAzCLI,
-		client:      &http.Client{},
+		acquireToken: aquireTokenFromAzCLI,
+		client:       &http.Client{},
 	}
 }
 
 // NewClientFromClientAndTokenFunc create a client for testing using custom token func and httpclient
 func NewClientFromClientAndTokenFunc(client *http.Client, tokenFunc TokenFunc) *Client {
 	return &Client{
-		aquireToken: tokenFunc,
-		client:      client,
+		acquireToken: tokenFunc,
+		client:       client,
 	}
 }
 
@@ -59,7 +59,7 @@ func (c *Client) SetClient(newClient *http.Client) {
 // SetAquireToken lets you override the token func for testing
 // or other purposes
 func (c *Client) SetAquireToken(aquireFunc func(clearCache bool) (AzCLIToken, error)) {
-	c.aquireToken = aquireFunc
+	c.acquireToken = aquireFunc
 }
 
 // GetTenantID gets the current tenandid from AzCli
@@ -69,7 +69,7 @@ func (c *Client) GetTenantID() string {
 
 // GetToken gets the cached cli token
 func (c *Client) GetToken() (AzCLIToken, error) {
-	return c.aquireToken(false)
+	return c.acquireToken(false)
 }
 
 // RequestResult used with async channel
@@ -111,7 +111,7 @@ func (c *Client) DoRequestWithBody(ctx context.Context, method, path, body strin
 		return "", errors.New("Failed to create request for body: " + err.Error())
 	}
 
-	cliToken, err := c.aquireToken(false)
+	cliToken, err := c.acquireToken(false)
 	if err != nil {
 		return "", errors.New("Failed to acquire auth token: " + err.Error())
 	}
@@ -127,7 +127,7 @@ func (c *Client) DoRequestWithBody(ctx context.Context, method, path, body strin
 	if response != nil && response.StatusCode == 401 {
 		// This might be because the token we've cached has expired.
 		// Get a new token forcing it to clear cache
-		cliToken, err := c.aquireToken(true)
+		cliToken, err := c.acquireToken(true)
 		if err != nil {
 			return "", errors.New("Failed to acquire auth token: " + err.Error())
 		}


### PR DESCRIPTION
I hit an issue where the fuzzer got stuck on an empty subscription

This PR
 * changes the `list.navigated` event to have a success flag and always fires the event
 * adds some extra checking in the fuzzer to move past non-successful navigations
 * also fixes up the fuzzer cmdline arg logic