### PR TITLE
Cleanup terminal on crash

### DIFF
--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -78,8 +78,20 @@ func run(settings *Settings) {
 	// Close the span used to track startup times
 	span.Finish()
 
+	// recover from panic if one occurred leaving terminal usable
+	defer func() {
+		if r := recover(); r != nil {
+			g.Close()
+			fmt.Printf("\n\nA crash occurred: %s \n", r)
+			debug.PrintStack()
+			fmt.Println("Please visit https://github.com/lawrencegripper/azbrowse/issues to raise a bug.")
+			os.Exit(1)
+		}
+	}()
+
 	// Start the main loop of gocui to draw the UI
 	if err := g.MainLoop(); err != nil && err != gocui.ErrQuit {
+		g.Close()
 		log.Panicln(err)
 	}
 }

--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/expanders"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/keybindings"
@@ -59,7 +60,18 @@ func run(settings *Settings) {
 	if err != nil {
 		log.Panicln(err)
 	}
+
+	// Give error handling the Gui instance so it can cleanup
+	// when a panic occurs
+	errorhandling.RegisterGuiInstance(g)
+
+	// recover from normal exit of the program
 	defer g.Close()
+
+	// recover from panic, if one occurrs, and leave terminal usable
+	defer errorhandling.RecoveryWithCleainup()
+
+	// Configure the gui instance
 	g.Highlight = true
 	g.SelFgColor = gocui.ColorCyan
 	g.InputEsc = true
@@ -78,20 +90,8 @@ func run(settings *Settings) {
 	// Close the span used to track startup times
 	span.Finish()
 
-	// recover from panic if one occurred leaving terminal usable
-	defer func() {
-		if r := recover(); r != nil {
-			g.Close()
-			fmt.Printf("\n\nA crash occurred: %s \n", r)
-			debug.PrintStack()
-			fmt.Println("Please visit https://github.com/lawrencegripper/azbrowse/issues to raise a bug.")
-			os.Exit(1)
-		}
-	}()
-
 	// Start the main loop of gocui to draw the UI
 	if err := g.MainLoop(); err != nil && err != gocui.ErrQuit {
-		g.Close()
 		log.Panicln(err)
 	}
 }
@@ -138,6 +138,8 @@ func configureTracing(settings *Settings) (context.Context, opentracing.Span) {
 
 func startPopulatingList(ctx context.Context, g *gocui.Gui, list *views.ListWidget, armClient *armclient.Client) {
 	go func() {
+		defer errorhandling.RecoveryWithCleainup()
+
 		time.Sleep(time.Second * 1)
 
 		_, done := eventing.SendStatusEvent(eventing.StatusEvent{
@@ -284,6 +286,9 @@ func handleNavigateTo(list *views.ListWidget, settings *Settings) {
 	if settings.NavigateToID != "" {
 		navigateToIDLower := strings.ToLower(settings.NavigateToID)
 		go func() {
+			// recover from panic, if one occurrs, and leave terminal usable
+			defer errorhandling.RecoveryWithCleainup()
+
 			navigatedChannel := eventing.SubscribeToTopic("list.navigated")
 			var lastNavigatedNode *expanders.TreeNode
 

--- a/internal/pkg/errorhandling/recovery.go
+++ b/internal/pkg/errorhandling/recovery.go
@@ -1,20 +1,36 @@
 package errorhandling
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime/debug"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/style"
 	"github.com/stuartleeks/gocui"
 )
 
 var gui *gocui.Gui
+var lastNavigationEvent []byte
 
 // RegisterGuiInstance track the gui instance we can use
 // to cleanup
 func RegisterGuiInstance(g *gocui.Gui) {
 	gui = g
+
+	go func() {
+		navigatedChannel := eventing.SubscribeToTopic("list.navigated")
+
+		for {
+			navEvent := <-navigatedChannel
+			if navEvent == nil {
+				continue
+			}
+			lastNavigationEvent, _ = json.Marshal(navEvent)
+
+		}
+	}()
 }
 
 // RecoveryWithCleainup cleans up a go routine panic
@@ -28,6 +44,7 @@ func RecoveryWithCleainup() {
 		fmt.Printf("\n\nPlease visit https://github.com/lawrencegripper/azbrowse/issues to raise a bug.\n")
 		fmt.Print("When raising please provide the details below in the issue.")
 		fmt.Printf(style.Subtle("\n\nStack Trace: \n%s\n"), debug.Stack())
+		fmt.Printf(style.Subtle("\n\nLast Navigation Event: \n%s\n"), lastNavigationEvent)
 		fmt.Println()
 		// debug.PrintStack()
 		os.Exit(1)

--- a/internal/pkg/errorhandling/recovery.go
+++ b/internal/pkg/errorhandling/recovery.go
@@ -1,36 +1,20 @@
 package errorhandling
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"runtime/debug"
 
-	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/style"
 	"github.com/stuartleeks/gocui"
 )
 
 var gui *gocui.Gui
-var lastNavigationEvent []byte
 
 // RegisterGuiInstance track the gui instance we can use
 // to cleanup
 func RegisterGuiInstance(g *gocui.Gui) {
 	gui = g
-
-	go func() {
-		navigatedChannel := eventing.SubscribeToTopic("list.navigated")
-
-		for {
-			navEvent := <-navigatedChannel
-			if navEvent == nil {
-				continue
-			}
-			lastNavigationEvent, _ = json.Marshal(navEvent)
-
-		}
-	}()
 }
 
 // RecoveryWithCleainup cleans up a go routine panic
@@ -44,7 +28,6 @@ func RecoveryWithCleainup() {
 		fmt.Printf("\n\nPlease visit https://github.com/lawrencegripper/azbrowse/issues to raise a bug.\n")
 		fmt.Print("When raising please provide the details below in the issue.")
 		fmt.Printf(style.Subtle("\n\nStack Trace: \n%s\n"), debug.Stack())
-		fmt.Printf(style.Subtle("\n\nLast Navigation Event: \n%s\n"), lastNavigationEvent)
 		fmt.Println()
 		// debug.PrintStack()
 		os.Exit(1)

--- a/internal/pkg/errorhandling/recovery.go
+++ b/internal/pkg/errorhandling/recovery.go
@@ -1,0 +1,35 @@
+package errorhandling
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+
+	"github.com/lawrencegripper/azbrowse/internal/pkg/style"
+	"github.com/stuartleeks/gocui"
+)
+
+var gui *gocui.Gui
+
+// RegisterGuiInstance track the gui instance we can use
+// to cleanup
+func RegisterGuiInstance(g *gocui.Gui) {
+	gui = g
+}
+
+// RecoveryWithCleainup cleans up a go routine panic
+// ensuring the terminal is left usable
+// Example: (required on all go routines)
+//  `defer errorhandling.RecoveryWithCleainup(recover())`
+func RecoveryWithCleainup() {
+	if r := recover(); r != nil {
+		gui.Close()
+		fmt.Printf(style.Warning("\n\nSorry a crash occurred\n Error: %s \n"), r)
+		fmt.Printf("\n\nPlease visit https://github.com/lawrencegripper/azbrowse/issues to raise a bug.\n")
+		fmt.Print("When raising please provide the details below in the issue.")
+		fmt.Printf(style.Subtle("\n\nStack Trace: \n%s\n"), debug.Stack())
+		fmt.Println()
+		// debug.PrintStack()
+		os.Exit(1)
+	}
+}

--- a/internal/pkg/expanders/expander.go
+++ b/internal/pkg/expanders/expander.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/tracing"
 )
@@ -46,6 +47,9 @@ func ExpandItem(ctx context.Context, currentItem *TreeNode) (*ExpanderResponse, 
 		// Fire each handler in parallel
 		hCurrent := h // capture current iteration variable
 		go func() {
+			// recover from panic, if one occurrs, and leave terminal usable
+			defer errorhandling.RecoveryWithCleainup()
+
 			completedExpands <- expanderAndResponse{
 				Expander:       hCurrent,
 				ExpanderResult: hCurrent.Expand(ctx, currentItem),

--- a/internal/pkg/expanders/resourcegroup.go
+++ b/internal/pkg/expanders/resourcegroup.go
@@ -97,8 +97,6 @@ func (e *ResourceGroupResourceExpander) Expand(ctx context.Context, currentItem 
 
 		queryDoneChan <- stateMap
 		span.SetTag("stateMap", stateMap)
-
-		panic("ooh")
 	}()
 
 	// Add deployment item

--- a/internal/pkg/expanders/resourcegroup.go
+++ b/internal/pkg/expanders/resourcegroup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/style"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/tracing"
@@ -54,6 +55,9 @@ func (e *ResourceGroupResourceExpander) Expand(ctx context.Context, currentItem 
 	queryDoneChan := make(chan map[string]string)
 	// Refactor this into DoResourceGraphQueryAync
 	go func() {
+		// recover from panic, if one occurrs, and leave terminal usable
+		defer errorhandling.RecoveryWithCleainup()
+
 		// Use resource graph to enrich response
 		query := "where resourceGroup=='" + currentItem.Name + "' | project name, id, sku, kind, location, tags, properties.provisioningState"
 		queryData, err := e.client.DoResourceGraphQuery(ctx, currentItem.SubscriptionID, query)

--- a/internal/pkg/expanders/resourcegroup.go
+++ b/internal/pkg/expanders/resourcegroup.go
@@ -97,6 +97,8 @@ func (e *ResourceGroupResourceExpander) Expand(ctx context.Context, currentItem 
 
 		queryDoneChan <- stateMap
 		span.SetTag("stateMap", stateMap)
+
+		panic("ooh")
 	}()
 
 	// Add deployment item

--- a/internal/pkg/tracing/appdash.go
+++ b/internal/pkg/tracing/appdash.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	opentracing "github.com/opentracing/opentracing-go"
 	"sourcegraph.com/sourcegraph/appdash"
 	appdashot "sourcegraph.com/sourcegraph/appdash/opentracing"
@@ -52,6 +53,9 @@ func StartTracing() func(opentracing.Span) string {
 		tapp.Store = store
 		tapp.Queryer = store
 		go func() {
+			// recover from panic, if one occurrs, and leave terminal usable
+			defer errorhandling.RecoveryWithCleainup()
+
 			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", appdashPort), tapp))
 		}()
 		traces, err := tapp.Queryer.Traces(appdash.TracesOpts{})

--- a/internal/pkg/views/notifications.go
+++ b/internal/pkg/views/notifications.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/expanders"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/style"
 	"github.com/lawrencegripper/azbrowse/pkg/armclient"
@@ -101,6 +102,9 @@ func (w *NotificationWidget) ConfirmDelete() {
 	w.deleteMutex.Unlock()
 
 	go func() {
+		// recover from panic, if one occurrs, and leave terminal usable
+		defer errorhandling.RecoveryWithCleainup()
+
 		// unlock and mark delete as not in progress
 		defer func() {
 			w.deleteInProgress = false

--- a/internal/pkg/views/statusbar.go
+++ b/internal/pkg/views/statusbar.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/style"
 	"github.com/stuartleeks/gocui"
@@ -38,6 +39,9 @@ func NewStatusbarWidget(x, y, w int, hideGuids bool, g *gocui.Gui) *StatusbarWid
 	newEvents := eventing.SubscribeToStatusEvents()
 	// Start loop for showing loading in statusbar
 	go func() {
+		// recover from panic, if one occurrs, and leave terminal usable
+		defer errorhandling.RecoveryWithCleainup()
+
 		for {
 			// Wait for a second to see if we have any new messages
 			timeout := time.After(time.Second)

--- a/pkg/armclient/armclient.go
+++ b/pkg/armclient/armclient.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/storage"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/tracing"
 )
@@ -82,6 +83,9 @@ type RequestResult struct {
 func (c *Client) DoRequestAsync(ctx context.Context, method, path string) chan RequestResult {
 	requestResultChan := make(chan RequestResult)
 	go func() {
+		// recover from panic, if one occurrs, and leave terminal usable
+		defer errorhandling.RecoveryWithCleainup()
+
 		data, err := c.DoRequestWithBody(ctx, method, path, "")
 		requestResultChan <- RequestResult{
 			Error:  err,


### PR DESCRIPTION
This change will catch a `panic` and ensure `azbrowse` returns the terminal to a working state before it closes. 