### PR TITLE
Bugfix(gopls): Prevent warning about outdated gopls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "--fast"
     ],
     "go.useLanguageServer": true,
+    "go.useGoProxyToCheckForToolUpdates": false,
     "go.inferGopath": false,
     "go.delveConfig": {
         "dlvLoadConfig": {


### PR DESCRIPTION
This prevents warning with a popup in vscode when gopls is not running the latest version. We pin our gopls version for consistency, and don't want to have to deal with this popup each time the container is used.

Fixes #209 