### PR TITLE
Re-enable "Update current item" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build: swagger-codegen test checks
 ## debug:
 ##		Starts azbrowse using Delve ready for debugging from VSCode.
 debug:
-	GO111MODULE=on go build ./cmd/azbrowse &&  dlv exec ./azbrowse --headless --listen localhost:2345 --api-version 2
+	GO111MODULE=on dlv debug ./cmd/azbrowse --headless --listen localhost:2345 --api-version 2
 
 ## dcterminal 
 ##		Starts an interactive terminal running inside the devcontainer

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ build: swagger-codegen test checks
 debug:
 	GO111MODULE=on dlv debug ./cmd/azbrowse --headless --listen localhost:2345 --api-version 2
 
+## debug-fuzzer:
+##		Starts azbrowse using Delve ready for debugging from VSCode and running the fuzzer.
+debug-fuzzer:
+	GO111MODULE=on dlv debug ./cmd/azbrowse --headless --listen localhost:2345 --api-version 2 -- -fuzzer 5
+
 ## dcterminal 
 ##		Starts an interactive terminal running inside the devcontainer
 dcterminal:

--- a/internal/pkg/keybindings/listhandlers.go
+++ b/internal/pkg/keybindings/listhandlers.go
@@ -498,6 +498,12 @@ func (h *ListUpdateHandler) IsEnabled() bool {
 func (h *ListUpdateHandler) Invoke() error {
 	item := h.Content.GetNode()
 	if !h.IsEnabled() {
+		eventing.SendStatusEvent(&eventing.StatusEvent{
+			InProgress: false,
+			Failure:    true,
+			Message:    "Updating not supported on this item",
+			Timeout:    time.Duration(time.Second * 2),
+		})
 		return nil
 	}
 

--- a/internal/pkg/keybindings/listhandlers.go
+++ b/internal/pkg/keybindings/listhandlers.go
@@ -485,7 +485,7 @@ func (h *ListUpdateHandler) DisplayText() string {
 	return "Update current item"
 }
 func (h *ListUpdateHandler) IsEnabled() bool {
-	item := h.List.CurrentExpandedItem()
+	item := h.Content.GetNode()
 	if item == nil ||
 		item.SwaggerResourceType == nil ||
 		item.SwaggerResourceType.PutEndpoint == nil ||
@@ -496,7 +496,7 @@ func (h *ListUpdateHandler) IsEnabled() bool {
 	return true
 }
 func (h *ListUpdateHandler) Invoke() error {
-	item := h.List.CurrentExpandedItem()
+	item := h.Content.GetNode()
 	if !h.IsEnabled() {
 		return nil
 	}
@@ -733,9 +733,9 @@ func (h *CommandPanelAzureSearchQueryHandler) CommandPanelNotification(state vie
 
 		data, err := searchApiSet.DoRequest("GET", currentItem.ExpandURL+"&"+queryString)
 		if err != nil {
-			h.content.SetContent(fmt.Sprintf("%s", err), expanders.ResponseJSON, queryString)
+			h.content.SetContent(nil, fmt.Sprintf("%s", err), expanders.ResponseJSON, queryString)
 		} else {
-			h.content.SetContent(data, expanders.ResponseJSON, queryString)
+			h.content.SetContent(nil, data, expanders.ResponseJSON, queryString)
 		}
 	}
 }

--- a/internal/pkg/views/itemview.go
+++ b/internal/pkg/views/itemview.go
@@ -23,6 +23,7 @@ type ItemWidget struct {
 	x, y         int
 	w, h         int
 	hideGuids    bool
+	node         *expanders.TreeNode
 	content      string
 	contentType  expanders.ExpanderResponseType
 	view         *gocui.View
@@ -148,8 +149,9 @@ func (w *ItemWidget) PageUp() {
 }
 
 // SetContent displays the string in the itemview
-func (w *ItemWidget) SetContent(content string, contentType expanders.ExpanderResponseType, title string) {
+func (w *ItemWidget) SetContent(node *expanders.TreeNode, content string, contentType expanders.ExpanderResponseType, title string) {
 	w.g.Update(func(g *gocui.Gui) error {
+		w.node = node
 		w.content = content
 		w.contentType = contentType
 		// Reset the cursor and origin (scroll poisition)
@@ -169,6 +171,11 @@ func (w *ItemWidget) GetContent() string {
 // GetContentType returns the current content type
 func (w *ItemWidget) GetContentType() expanders.ExpanderResponseType {
 	return w.contentType
+}
+
+// GetNode returns the TreeNode associated with the currently displayed content (or nil if content is not related to a node)
+func (w *ItemWidget) GetNode() *expanders.TreeNode {
+	return w.node
 }
 
 // SetShouldRender set the shouldRender value of this item

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -209,7 +209,7 @@ func (w *ListWidget) GoBack() {
 		eventing.Publish("list.navigated", ListNavigatedEventState{Success: false})
 		return
 	}
-	w.contentView.SetContent(previousPage.Data, previousPage.DataType, "Response")
+	w.contentView.SetContent(previousPage.ExpandedNodeItem, previousPage.Data, previousPage.DataType, "Response")
 	w.selected = 0
 	w.items = previousPage.Value
 	w.title = previousPage.Title
@@ -254,31 +254,30 @@ func (w *ListWidget) Navigate(nodes []*expanders.TreeNode, content *expanders.Ex
 		eventing.Publish("list.navigated", ListNavigatedEventState{Success: false})
 	}
 	currentItem := w.CurrentItem()
+
+	parentNodeID := "root"
+	nodeID := "root"
+	if w.expandedNodeItem != nil {
+		parentNodeID = w.expandedNodeItem.ID
+		nodeID = currentItem.ID
+	}
+
+	w.contentView.SetContent(currentItem, content.Response, content.ResponseType, title)
 	if len(nodes) > 0 {
 		w.expandedNodeItem = currentItem
 		w.SetNodes(nodes)
+
+		if currentItem != nil {
+			w.title = w.title + "fooo>" + currentItem.Name
+		}
 	}
 
-	w.contentView.SetContent(content.Response, content.ResponseType, title)
-	if currentItem != nil {
-		w.title = w.title + ">" + currentItem.Name
-	}
-
-	if w.expandedNodeItem != nil {
-		eventing.Publish("list.navigated", ListNavigatedEventState{
-			Success:      true,
-			NewNodes:     nodes,
-			ParentNodeID: w.expandedNodeItem.ID,
-			NodeID:       currentItem.ID,
-		})
-	} else {
-		eventing.Publish("list.navigated", ListNavigatedEventState{
-			Success:      true,
-			NewNodes:     nodes,
-			ParentNodeID: "root",
-			NodeID:       "root",
-		})
-	}
+	eventing.Publish("list.navigated", ListNavigatedEventState{
+		Success:      true,
+		NewNodes:     nodes,
+		ParentNodeID: parentNodeID,
+		NodeID:       nodeID,
+	})
 }
 
 // GetNodes returns the currently listed nodes

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -255,21 +255,21 @@ func (w *ListWidget) Navigate(nodes []*expanders.TreeNode, content *expanders.Ex
 	}
 	currentItem := w.CurrentItem()
 
-	parentNodeID := "root"
-	nodeID := "root"
-	if w.expandedNodeItem != nil {
-		parentNodeID = w.expandedNodeItem.ID
-		nodeID = currentItem.ID
-	}
-
 	w.contentView.SetContent(currentItem, content.Response, content.ResponseType, title)
 	if len(nodes) > 0 {
 		w.expandedNodeItem = currentItem
 		w.SetNodes(nodes)
 
 		if currentItem != nil {
-			w.title = w.title + "fooo>" + currentItem.Name
+			w.title = w.title + ">" + currentItem.Name
 		}
+	}
+
+	parentNodeID := "root"
+	nodeID := "root"
+	if w.expandedNodeItem != nil {
+		parentNodeID = w.expandedNodeItem.ID
+		nodeID = currentItem.ID
 	}
 
 	eventing.Publish("list.navigated", ListNavigatedEventState{


### PR DESCRIPTION
Leaf node navigation now stores the node on the Content view and the ListUpdate command now checks the Content view node. This allows resource editing to work without reverting to behaviour that allows infinite expansion of a leaf node.

PR also changes `make debug` to use `dlv debug` as this gives a richer debug experience compared to debugging the compiled binary. Happy to pull this into a separate PR if preferred

Fixes #222
