### PR TITLE
Move ListCopyItemIDHandler to ItemCopyItemIDHandler

### DIFF
--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -214,7 +214,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 	listActionsCommand := keybindings.NewListActionsHandler(list, ctx)
 	listOpenCommand := keybindings.NewListOpenHandler(list, ctx)
 	listUpdateCommand := keybindings.NewListUpdateHandler(list, status, ctx, content, g)
-	listCopyItemIDCommand := keybindings.NewListCopyItemIDHandler(list, status)
+	itemCopyItemIDCommand := keybindings.NewItemCopyItemIDHandler(content, status)
 	listDebugCopyItemDataCommand := keybindings.NewListDebugCopyItemDataHandler(list, status)
 
 	commands := []keybindings.Command{
@@ -224,7 +224,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 		listActionsCommand,
 		listOpenCommand,
 		listUpdateCommand,
-		listCopyItemIDCommand,
+		itemCopyItemIDCommand,
 		toggleDemoModeCommand,
 	}
 	if settings.EnableTracing {
@@ -275,7 +275,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 	keybindings.AddHandler(keybindings.NewListHomeHandler(list))
 	keybindings.AddHandler(keybindings.NewListClearFilterHandler(list))
 	keybindings.AddHandler(commandPanelAzureSearchQueryCommand)
-	keybindings.AddHandler(listCopyItemIDCommand)
+	keybindings.AddHandler(itemCopyItemIDCommand)
 	if settings.EnableTracing {
 		keybindings.AddHandler(listDebugCopyItemDataCommand)
 	}

--- a/internal/pkg/keybindings/itemhandlers.go
+++ b/internal/pkg/keybindings/itemhandlers.go
@@ -1,6 +1,8 @@
 package keybindings
 
 import (
+	"fmt"
+
 	"github.com/lawrencegripper/azbrowse/internal/pkg/views"
 	"github.com/stuartleeks/gocui"
 )
@@ -98,6 +100,51 @@ func (h ItemViewPageUpHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
 		h.ItemView.PageUp()
 		return nil
 	}
+}
+
+////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////
+type ItemCopyItemIDHandler struct {
+	ListHandler
+	Item      *views.ItemWidget
+	StatusBar *views.StatusbarWidget
+}
+
+var _ Command = &ItemCopyItemIDHandler{}
+
+func NewItemCopyItemIDHandler(item *views.ItemWidget, statusBar *views.StatusbarWidget) *ItemCopyItemIDHandler {
+	handler := &ItemCopyItemIDHandler{
+		Item:      item,
+		StatusBar: statusBar,
+	}
+	handler.id = HandlerIDListCopyItemID
+	return handler
+}
+
+func (h ItemCopyItemIDHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		return h.Invoke()
+	}
+}
+
+func (h *ItemCopyItemIDHandler) DisplayText() string {
+	return "Copy current resource ID"
+}
+func (h *ItemCopyItemIDHandler) IsEnabled() bool {
+	return h.Item.GetNode() != nil
+}
+func (h *ItemCopyItemIDHandler) Invoke() error {
+	item := h.Item.GetNode()
+	if item != nil {
+		if err := copyToClipboard(item.ID); err != nil {
+			h.StatusBar.Status(fmt.Sprintf("Failed to copy resource ID to clipboard: %s", err.Error()), false)
+			return nil
+		}
+		h.StatusBar.Status("Current resource ID copied to clipboard", false)
+		return nil
+	}
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/internal/pkg/keybindings/listhandlers.go
+++ b/internal/pkg/keybindings/listhandlers.go
@@ -749,51 +749,6 @@ func (h *CommandPanelAzureSearchQueryHandler) CommandPanelNotification(state vie
 ////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////
-type ListCopyItemIDHandler struct {
-	ListHandler
-	List      *views.ListWidget
-	StatusBar *views.StatusbarWidget
-}
-
-var _ Command = &ListCopyItemIDHandler{}
-
-func NewListCopyItemIDHandler(list *views.ListWidget, statusBar *views.StatusbarWidget) *ListCopyItemIDHandler {
-	handler := &ListCopyItemIDHandler{
-		List:      list,
-		StatusBar: statusBar,
-	}
-	handler.id = HandlerIDListCopyItemID
-	return handler
-}
-
-func (h ListCopyItemIDHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
-	return func(g *gocui.Gui, v *gocui.View) error {
-		return h.Invoke()
-	}
-}
-
-func (h *ListCopyItemIDHandler) DisplayText() string {
-	return "Copy current resource ID"
-}
-func (h *ListCopyItemIDHandler) IsEnabled() bool {
-	return h.List.CurrentExpandedItem() != nil
-}
-func (h *ListCopyItemIDHandler) Invoke() error {
-	item := h.List.CurrentExpandedItem()
-	if item != nil {
-		if err := copyToClipboard(item.ID); err != nil {
-			h.StatusBar.Status(fmt.Sprintf("Failed to copy resource ID to clipboard: %s", err.Error()), false)
-			return nil
-		}
-		h.StatusBar.Status("Current resource ID copied to clipboard", false)
-		return nil
-	}
-	return nil
-}
-
-////////////////////////////////////////////////////////////////////
-
-////////////////////////////////////////////////////////////////////
 type ListDebugCopyItemDataHandler struct {
 	ListHandler
 	List      *views.ListWidget


### PR DESCRIPTION
Fixes #234 

Move `ListCopyItemIDHandler` to `ItemCopyItemIDHandler` and take a `ContentWidget` instead of `ListWidget` to get the current item