### PR TITLE
Initial Databricks workspace browsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ swagger-codegen:
 	# Format the generated code
 	gofmt -s -w internal/pkg/expanders/swagger-armspecs.generated.go
 	gofmt -s -w internal/pkg/expanders/search.generated.go
+	gofmt -s -w internal/pkg/expanders/databricks.generated.go
 	# Build the generated go files to check for any go build issues
 	$(GO_BINARY) build internal/pkg/expanders/swagger-armspecs.generated.go internal/pkg/expanders/swagger-armspecs.go internal/pkg/expanders/swagger.go internal/pkg/expanders/types.go internal/pkg/expanders/test_utils.go
 	# Test the generated code initalizes

--- a/cmd/swagger-codegen/main.go
+++ b/cmd/swagger-codegen/main.go
@@ -261,6 +261,9 @@ func getDatabricksDataPlaneConfig() *swagger.Config {
 		AdditionalPaths: []swagger.AdditionalPath{
 			// add as a missing path - also overridden to map to the actual endpoint that exists!
 			{Name: "{scope}", Path: "/api/2.0/secrets/{scope}"},
+			// Add extra point for runs listing
+			{Name: "runs", Path: "/api/2.0/runs", GetPath: "/api/2.0/jobs/runs/list"},
+			{Name: "{run_id}", Path: "/api/2.0/runs/{run_id}", GetPath: "/api/2.0/jobs/runs/get", DeletePath: "/api/2.0/jobs/runs/delete"},
 		},
 		// Override the some paths to relate them to each other better
 		Overrides: map[string]swagger.PathOverride{

--- a/cmd/swagger-codegen/main.go
+++ b/cmd/swagger-codegen/main.go
@@ -260,7 +260,7 @@ func getDatabricksDataPlaneConfig() *swagger.Config {
 		SuppressAPIVersion: true,
 		AdditionalPaths: []swagger.AdditionalPath{
 			// add as a missing path - also overridden to map to the actual endpoint that exists!
-			{Name: "{scope}", Path: "/api/2.0/secrets/{scope}"},
+			{Name: "{scope}", Path: "/api/2.0/secrets/{scope}", DeletePath: "/api/2.0/secrets/scopes/delete"},
 			// Add extra point for runs listing
 			{Name: "runs", Path: "/api/2.0/runs", GetPath: "/api/2.0/jobs/runs/list"},
 			{Name: "{run_id}", Path: "/api/2.0/runs/{run_id}", GetPath: "/api/2.0/jobs/runs/get", DeletePath: "/api/2.0/jobs/runs/delete"},

--- a/cmd/swagger-codegen/main.go
+++ b/cmd/swagger-codegen/main.go
@@ -53,6 +53,14 @@ func main() {
 	paths = loadAzureSearchDataPlaneSpecs(config)
 	writeOutput(paths, config, "./internal/pkg/expanders/search.generated.go", "AzureSearchServiceExpander")
 	fmt.Println()
+
+	fmt.Println("*******************************************")
+	fmt.Println("  Processing Databricks Data-plane Specs ")
+	fmt.Println("*******************************************")
+	config = getDatabricksDataPlaneConfig()
+	paths = loadDatabricksDataPlaneSpecs(config)
+	writeOutput(paths, config, "./internal/pkg/expanders/databricks.generated.go", "AzureDatabricksExpander")
+	fmt.Println()
 }
 
 // APISet matches the structure of `api-set.json` files from swagger-update
@@ -242,6 +250,72 @@ func loadAzureSearchDataPlaneSpecs(config *swagger.Config) []*swagger.Path {
 				}
 			}
 		}
+	}
+	return paths
+}
+
+// getARMConfig returns the config for ARM Swagger processing
+func getDatabricksDataPlaneConfig() *swagger.Config {
+	return &swagger.Config{
+		SuppressAPIVersion: true,
+		AdditionalPaths: []swagger.AdditionalPath{
+			// add as a missing path - also overridden to map to the actual endpoint that exists!
+			{Name: "{scope}", Path: "/api/2.0/secrets/{scope}"},
+		},
+		// Override the some paths to relate them to each other better
+		Overrides: map[string]swagger.PathOverride{
+			"/api/2.0/clusters/get": { // push cluster get under cluster list
+				Path:       "/api/2.0/clusters/list/{cluster_id}",
+				PutPath:    "/api/2.0/clusters/edit",
+				DeletePath: "/api/2.0/clusters/permanent-delete",
+			},
+
+			"/api/2.0/instance-pools/list": {
+				Path: "/api/2.0/instance-pools",
+			},
+			"/api/2.0/instance-pools/get": {
+				Path:       "/api/2.0/instance-pools/{instance_pool_id}",
+				DeletePath: "/api/2.0/instance-pools/delete",
+			},
+
+			"/api/2.0/jobs/list": { // tweak job list path to be sorted before others!
+				Path: "/api/2.0/jobs",
+			},
+			"/api/2.0/jobs/get": { // push job get under job list
+				Path:       "/api/2.0/jobs/{job_id}",
+				DeletePath: "/api/2.0/jobs/delete",
+			},
+			"/api/2.0/jobs/runs/list": { // push run list under job get
+				Path: "/api/2.0/jobs/{job_id}/runs",
+			},
+			"/api/2.0/jobs/runs/get": { // push run get under run list
+				Path:       "/api/2.0/jobs/{job_id}/runs/{run_id}",
+				DeletePath: "/api/2.0/jobs/runs/delete",
+			},
+
+			"/api/2.0/secrets/scopes/list": { // Ensure secret scope list is sorted top for secrets urls
+				Path: "/api/2.0/secrets",
+			},
+			"/api/2.0/secrets/list": { // push secrets under secret scopes
+				Path: "/api/2.0/secrets/{scope}/secrets",
+			},
+			"/api/2.0/secrets/acls/list": { // push secret acls under secret scopes
+				Path: "/api/2.0/secrets/{scope}/acls",
+			},
+			"/api/2.0/secrets/acls/get": { // push secret acls under secret scopes
+				Path: "/api/2.0/secrets/{scope}/acls/{principal}",
+			},
+		},
+	}
+}
+func loadDatabricksDataPlaneSpecs(config *swagger.Config) []*swagger.Path {
+	var paths []*swagger.Path
+
+	doc := loadDoc("custom-swagger-specs/databricks.json")
+	pathPrefix := ""
+	paths, err := swagger.MergeSwaggerDoc(paths, config, doc, true, pathPrefix)
+	if err != nil {
+		panic(err)
 	}
 	return paths
 }

--- a/cmd/swagger-codegen/main_tmpl.go
+++ b/cmd/swagger-codegen/main_tmpl.go
@@ -13,6 +13,8 @@ const tmpl = `
 	PatchEndpoint: endpoints.MustGetEndpointInfoFromURL("{{ .Operations.Patch.Endpoint.TemplateURL }}", "{{ .Operations.Patch.Endpoint.APIVersion}}"),{{end}}
 	{{- if .Operations.Put.Permitted }}
 	PutEndpoint: endpoints.MustGetEndpointInfoFromURL("{{ .Operations.Put.Endpoint.TemplateURL }}", "{{ .Operations.Put.Endpoint.APIVersion}}"),{{end}}
+	{{- if .FixedContent}}
+	FixedContent: "{{ .FixedContent}}",{{end}}
 	{{- if .Children}}
 	Children: {{template "PathList" .Children}},{{end}}
 	{{- if .SubPaths}}

--- a/custom-swagger-specs/databricks.json
+++ b/custom-swagger-specs/databricks.json
@@ -1,0 +1,225 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.1",
+        "title": "databricks",
+        "description": "minimal spec for databricks REST API to use with azbrowse codegen",
+        "termsOfService": "blah",
+        "license": {
+            "name": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+        }
+    },
+    "paths": {
+        "/api/2.0/clusters/list": {
+            "get": {
+                "description": "list clusters",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/clusters/get": {
+            "get": {
+                "description": "get cluster",
+                "parameters": [
+                    {
+                        "name": "cluster_id",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "foo"
+                    }
+                }
+            }
+        },
+        "/api/2.0/jobs/list": {
+            "get": {
+                "description": "list jobs",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/jobs/get": {
+            "get": {
+                "description": "get job",
+                "parameters": [
+                    {
+                        "name": "job_id",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "foo"
+                    }
+                }
+            }
+        },
+        "/api/2.0/jobs/runs/list": {
+            "get": {
+                "description": "list runs",
+                "parameters": [
+                    {
+                        "name": "job_id",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/jobs/runs/get": {
+            "get": {
+                "description": "get run",
+                "parameters": [
+                    {
+                        "name": "run_id",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "foo"
+                    }
+                }
+            }
+        },
+        "/api/2.0/secrets/scopes/list": {
+            "get": {
+                "description": "list secret scopes",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/secrets/list": {
+            "get": {
+                "description": "list secrets",
+                "parameters": [
+                    {
+                        "name": "scope",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/secrets/acls/list": {
+            "get": {
+                "description": "list secret scope ACL",
+                "parameters": [
+                    {
+                        "name": "scope",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/secrets/acls/get": {
+            "get": {
+                "description": "get secret scope ACL",
+                "parameters": [
+                    {
+                        "name": "scope",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "principal",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/groups/list": {
+            "get": {
+                "description": "list groups",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/instance-pools/list": {
+            "get": {
+                "description": "list instance pools",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/2.0/instance-pools/get": {
+            "get": {
+                "description": "get instance pool",
+                "parameters": [
+                    {
+                        "name": "instance_pool_id",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "foo"
+                    }
+                }
+            }
+        },
+        "/api/2.0/token/list": {
+            "get": {
+                "description": "list tokens",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}

--- a/internal/pkg/expanders/databricks-swaggerApiSet.go
+++ b/internal/pkg/expanders/databricks-swaggerApiSet.go
@@ -239,7 +239,7 @@ func (c SwaggerAPISetDatabricks) Delete(ctx context.Context, item *TreeNode) (bo
 		bodyValue["job_id"] = metadata["job_id"]
 	case "/api/2.0/jobs/runs/get":
 		bodyValue["run_id"] = metadata["run_id"]
-	case "/api/2.0/secrets/scopes/get":
+	case "/api/2.0/secrets/{scope}":
 		bodyValue["scope"] = metadata["scope"]
 	case "/api/2.0/secrets/get":
 		bodyValue["scope"] = metadata["scope"]

--- a/internal/pkg/expanders/databricks-swaggerApiSet.go
+++ b/internal/pkg/expanders/databricks-swaggerApiSet.go
@@ -1,0 +1,262 @@
+package expanders
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/lawrencegripper/azbrowse/pkg/swagger"
+)
+
+var _ SwaggerAPISet = SwaggerAPISetDatabricks{}
+
+// SwaggerAPISetDatabricks holds the config for working with an Azure Search Service
+type SwaggerAPISetDatabricks struct {
+	resourceTypes   []swagger.ResourceType
+	httpClient      http.Client
+	workspaceID     string // ARM resource ID for the search service (/subscriptions/....)
+	nodeID          string
+	workspaceURL    string
+	managementToken string
+	databricksToken string
+}
+
+// NewSwaggerAPISetDatabricks creates a new SwaggerAPISetDatabricks
+func NewSwaggerAPISetDatabricks(resourceTypes []swagger.ResourceType, workspaceID string, nodeID string, workspaceURL string, managementToken string, databricksToken string) SwaggerAPISetDatabricks {
+	c := SwaggerAPISetDatabricks{}
+	c.resourceTypes = resourceTypes
+	c.httpClient = http.Client{}
+	c.workspaceID = workspaceID
+	c.nodeID = nodeID
+	c.workspaceURL = workspaceURL
+	c.managementToken = managementToken
+	c.databricksToken = databricksToken
+	return c
+}
+
+// ID returns the ID for the APISet
+func (c SwaggerAPISetDatabricks) ID() string {
+	return c.nodeID
+}
+
+// MatchChildNodesByName indicates whether child nodes should be matched by name (or position)
+func (c SwaggerAPISetDatabricks) MatchChildNodesByName() bool {
+	return true
+}
+
+// AppliesToNode is called by the Swagger exapnder to test whether the node applies to this APISet
+func (c SwaggerAPISetDatabricks) AppliesToNode(node *TreeNode) bool {
+	// this function is only called for nodes that don't have the SwaggerAPISetID set
+	// this should never happen for search nodes
+	return false
+}
+
+// GetResourceTypes returns the ResourceTypes for the API Set
+func (c SwaggerAPISetDatabricks) GetResourceTypes() []swagger.ResourceType {
+	return c.resourceTypes
+}
+
+// DoRequest makes a request against the search endpoint
+func (c SwaggerAPISetDatabricks) DoRequest(verb string, url string) (string, error) {
+	return c.DoRequestWithBody(verb, url, "")
+}
+
+// DoRequestWithBody makes a request against the search endpoint
+func (c SwaggerAPISetDatabricks) DoRequestWithBody(verb string, url string, body string) (string, error) {
+	return c.DoRequestWithBodyAndHeaders(verb, url, body, map[string]string{})
+}
+
+// DoRequestWithBodyAndHeaders makes a request against the search endpoint
+func (c SwaggerAPISetDatabricks) DoRequestWithBodyAndHeaders(verb string, url string, body string, headers map[string]string) (string, error) {
+
+	request, err := http.NewRequest(verb, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		err = fmt.Errorf("Failed to create request" + err.Error() + url)
+		return "", err
+	}
+
+	request.Header.Set("Authorization", "Bearer "+c.databricksToken)
+	request.Header.Set("X-Databricks-Azure-SP-Management-Token", c.managementToken)
+	request.Header.Set("X-Databricks-Azure-Workspace-Resource-Id", c.workspaceID)
+	for name, value := range headers {
+		request.Header.Set(name, value)
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		err = fmt.Errorf("Failed" + err.Error() + url)
+		return "", err
+	}
+	defer response.Body.Close() //nolint: errcheck
+	buf, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		err = fmt.Errorf("Failed to read body: %s", err)
+		return "", err
+	}
+	data := string(buf)
+	if 200 <= response.StatusCode && response.StatusCode < 300 {
+		return data, nil
+	}
+	return "", fmt.Errorf("Response failed with %s (%s): %s", response.Status, url, data)
+}
+
+// ExpandResource returns metadata about child resources of the specified resource node
+func (c SwaggerAPISetDatabricks) ExpandResource(ctx context.Context, currentItem *TreeNode, resourceType swagger.ResourceType) (APISetExpandResponse, error) {
+
+	if currentItem.SwaggerResourceType.Endpoint.TemplateURL == "/api/2.0/secrets/{scope}" {
+		// fake node added to tree structure
+		// no resources to add, but pass child metadata
+		return APISetExpandResponse{
+			Response:      "Choose a node to expand...",
+			ResponseType:  ResponsePlainText,
+			ChildMetadata: currentItem.Metadata,
+		}, nil
+	}
+
+	if currentItem.ExpandURL == "/api/2.0/secrets/list" || currentItem.ExpandURL == "/api/2.0/secrets/acls/list" {
+		// handle query string values for items that were added as Child nodes by the swagger expander
+
+		// TODO Update DeleteURL  when handling deletion!
+		currentItem.ExpandURL = currentItem.ExpandURL + "?scope=" + currentItem.Metadata["scope"]
+	}
+
+	subResources := []SubResource{}
+	url := "https://" + c.workspaceURL + currentItem.ExpandURL
+	data, err := c.DoRequest("GET", url)
+	if err != nil {
+		err = fmt.Errorf("Failed to make request: %s", err)
+		return APISetExpandResponse{}, err
+	}
+	if len(resourceType.SubResources) > 0 {
+		// We have defined subResources - Unmarshal the response and add these to newItems
+		// TODO!
+
+		if len(resourceType.SubResources) > 1 {
+			return APISetExpandResponse{}, fmt.Errorf("Only expecting a single SubResource type")
+		}
+		subResourceType := resourceType.SubResources[0]
+
+		arrayPath, idPropertyName, queryStringName, additionalQueryStrings := c.getExpandParameters(currentItem.SwaggerResourceType.Endpoint.TemplateURL)
+
+		var jsonData map[string]interface{}
+		if err = json.Unmarshal([]byte(data), &jsonData); err != nil {
+			return APISetExpandResponse{}, err
+		}
+		itemArrayTemp := jsonData[arrayPath]
+		if itemArrayTemp != nil {
+			itemArray := itemArrayTemp.([]interface{})
+
+			for _, item := range itemArray {
+				item := item.(map[string]interface{})
+				itemIDTemp := item[idPropertyName]
+				itemID := fmt.Sprintf("%v", itemIDTemp)
+				expandURL := fmt.Sprintf("%s?%s=%s", subResourceType.Endpoint.TemplateURL, queryStringName, itemID)
+
+				for _, queryStringName := range additionalQueryStrings {
+					queryStringValue := currentItem.Metadata[queryStringName]
+					expandURL += fmt.Sprintf("&%s=%s", queryStringName, queryStringValue)
+				}
+
+				metadata := map[string]string{}
+				for k, v := range currentItem.Metadata {
+					metadata[k] = v
+				}
+				metadata[queryStringName] = itemID
+
+				subResource := SubResource{
+					ID:           c.nodeID + expandURL,
+					ResourceType: subResourceType,
+					ExpandURL:    expandURL,
+					Name:         itemID,
+					Metadata:     metadata,
+				}
+				if subResourceType.DeleteEndpoint != nil && subResourceType.DeleteEndpoint.TemplateURL != "" {
+					subResource.DeleteURL = subResourceType.DeleteEndpoint.TemplateURL // delete urls are all fixed values
+				}
+
+				subResources = append(subResources, subResource)
+			}
+		}
+	}
+
+	return APISetExpandResponse{
+		Response:     data,
+		ResponseType: ResponseJSON,
+		SubResources: subResources,
+	}, nil
+}
+
+// get returns arrayPath, idPropertyName, queryStringName and an array of additional query strings to pass
+func (c SwaggerAPISetDatabricks) getExpandParameters(templateURL string) (string, string, string, []string) {
+	switch templateURL {
+	case "/api/2.0/clusters/list":
+		return "clusters", "cluster_id", "cluster_id", []string{}
+	case "/api/2.0/instance-pools/list":
+		return "instance_pools", "instance_pool_id", "instance_pool_id", []string{}
+	case "/api/2.0/jobs/list":
+		return "jobs", "job_id", "job_id", []string{}
+	case "/api/2.0/jobs/runs/list":
+		return "runs", "run_id", "run_id", []string{}
+	case "/api/2.0/secrets/scopes/list":
+		return "scopes", "name", "scope", []string{}
+	case "/api/2.0/secrets/list":
+		return "secrets", "key", "key", []string{}
+	case "/api/2.0/secrets/acls/list":
+		return "items", "principal", "principal", []string{"scope"}
+	case "/api/2.0/token/list":
+		return "token_infos", "token_id", "token_id", []string{"scope"}
+	}
+	return "", "", "", []string{}
+}
+
+// Delete attempts to delete the item. Returns true if deleted, false if not handled, an error if an error occurred attempting to delete
+func (c SwaggerAPISetDatabricks) Delete(ctx context.Context, item *TreeNode) (bool, error) {
+	if item.DeleteURL == "" {
+		return false, fmt.Errorf("Item cannot be deleted (No DeleteURL)")
+	}
+
+	metadata := item.Metadata
+	bodyValue := map[string]interface{}{}
+
+	switch item.SwaggerResourceType.Endpoint.TemplateURL {
+	case "/api/2.0/clusters/get":
+		bodyValue["cluster_id"] = metadata["cluster_id"]
+	case "/api/2.0/instance-pools/get":
+		bodyValue["instance_pool_id"] = metadata["instance_pool_id"]
+	case "/api/2.0/jobs/get":
+		bodyValue["job_id"] = metadata["job_id"]
+	case "/api/2.0/jobs/runs/get":
+		bodyValue["run_id"] = metadata["run_id"]
+	case "/api/2.0/secrets/scopes/get":
+		bodyValue["scope"] = metadata["scope"]
+	case "/api/2.0/secrets/get":
+		bodyValue["scope"] = metadata["scope"]
+		bodyValue["key"] = metadata["key"]
+	case "/api/2.0/secrets/acls/get":
+		bodyValue["scope"] = metadata["scope"]
+		bodyValue["principal"] = metadata["principal"]
+	}
+
+	if len(bodyValue) > 0 {
+		bodyBuf, err := json.Marshal(bodyValue)
+		if err != nil {
+			return false, fmt.Errorf("Failed to serialize DELETE body: %v", err)
+		}
+		body := string(bodyBuf)
+		url := "https://" + c.workspaceURL + item.DeleteURL
+		_, err = c.DoRequestWithBody("POST", url, body)
+		if err != nil {
+			return false, fmt.Errorf("Failed to serialize DELETE body: %v", err)
+		}
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Not implemented")
+}
+
+// Update attempts to update the specified item with new content
+func (c SwaggerAPISetDatabricks) Update(ctx context.Context, item *TreeNode, content string) error {
+	return fmt.Errorf("Not implemented")
+}

--- a/internal/pkg/expanders/databricks.generated.go
+++ b/internal/pkg/expanders/databricks.generated.go
@@ -1,0 +1,84 @@
+package expanders
+
+import (
+	"github.com/lawrencegripper/azbrowse/pkg/endpoints"
+	"github.com/lawrencegripper/azbrowse/pkg/swagger"
+)
+
+func (e *AzureDatabricksExpander) loadResourceTypes() []swagger.ResourceType {
+	return []swagger.ResourceType{
+		{
+			Display:  "clusters",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/clusters/list", ""),
+			SubResources: []swagger.ResourceType{
+				{
+					Display:        "{cluster_id}",
+					Endpoint:       endpoints.MustGetEndpointInfoFromURL("/api/2.0/clusters/get", ""),
+					DeleteEndpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/clusters/permanent-delete", ""),
+					PutEndpoint:    endpoints.MustGetEndpointInfoFromURL("/api/2.0/clusters/edit", ""),
+				}},
+		},
+		{
+			Display:  "groups",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/groups/list", ""),
+		},
+		{
+			Display:  "instance-pools",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/instance-pools/list", ""),
+			SubResources: []swagger.ResourceType{
+				{
+					Display:        "{instance_pool_id}",
+					Endpoint:       endpoints.MustGetEndpointInfoFromURL("/api/2.0/instance-pools/get", ""),
+					DeleteEndpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/instance-pools/delete", ""),
+				}},
+		},
+		{
+			Display:  "jobs",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/list", ""),
+			SubResources: []swagger.ResourceType{
+				{
+					Display:        "{job_id}",
+					Endpoint:       endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/get", ""),
+					DeleteEndpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/delete", ""),
+					Children: []swagger.ResourceType{
+						{
+							Display:  "runs",
+							Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/runs/list", ""),
+							SubResources: []swagger.ResourceType{
+								{
+									Display:        "{run_id}",
+									Endpoint:       endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/runs/get", ""),
+									DeleteEndpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/runs/delete", ""),
+								}},
+						}},
+				}},
+		},
+		{
+			Display:  "secrets",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/scopes/list", ""),
+			SubResources: []swagger.ResourceType{
+				{
+					Display:  "{scope}",
+					Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/{scope}", ""),
+					Children: []swagger.ResourceType{
+						{
+							Display:  "acls",
+							Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/acls/list", ""),
+							SubResources: []swagger.ResourceType{
+								{
+									Display:  "{principal}",
+									Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/acls/get", ""),
+								}},
+						},
+						{
+							Display:  "secrets",
+							Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/list", ""),
+						}},
+				}},
+		},
+		{
+			Display:  "token",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/token/list", ""),
+		}}
+
+}

--- a/internal/pkg/expanders/databricks.generated.go
+++ b/internal/pkg/expanders/databricks.generated.go
@@ -68,8 +68,9 @@ func (e *AzureDatabricksExpander) loadResourceTypes() []swagger.ResourceType {
 			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/scopes/list", ""),
 			SubResources: []swagger.ResourceType{
 				{
-					Display:  "{scope}",
-					Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/{scope}", ""),
+					Display:        "{scope}",
+					Endpoint:       endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/{scope}", ""),
+					DeleteEndpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/scopes/delete", ""),
 					Children: []swagger.ResourceType{
 						{
 							Display:  "acls",

--- a/internal/pkg/expanders/databricks.generated.go
+++ b/internal/pkg/expanders/databricks.generated.go
@@ -54,6 +54,16 @@ func (e *AzureDatabricksExpander) loadResourceTypes() []swagger.ResourceType {
 				}},
 		},
 		{
+			Display:  "runs",
+			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/runs/list", ""),
+			SubResources: []swagger.ResourceType{
+				{
+					Display:        "{run_id}",
+					Endpoint:       endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/runs/get", ""),
+					DeleteEndpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/jobs/runs/delete", ""),
+				}},
+		},
+		{
 			Display:  "secrets",
 			Endpoint: endpoints.MustGetEndpointInfoFromURL("/api/2.0/secrets/scopes/list", ""),
 			SubResources: []swagger.ResourceType{

--- a/internal/pkg/expanders/databricks.go
+++ b/internal/pkg/expanders/databricks.go
@@ -66,8 +66,8 @@ func (e *AzureDatabricksExpander) Expand(ctx context.Context, currentItem *TreeN
 			ID:        currentItem.ID + "/<workspace>",
 			Parentid:  currentItem.ID,
 			Namespace: "AzureDatabricksExpander",
-			Name:      "Connect to Databricks workspace...",
-			Display:   "Connect to Databricks workspace...",
+			Name:      "Connect to Databricks workspace",
+			Display:   "Connect to Databricks workspace",
 			ItemType:  SubResourceType,
 			ExpandURL: ExpandURLNotSupported,
 			Metadata: map[string]string{

--- a/internal/pkg/expanders/databricks.go
+++ b/internal/pkg/expanders/databricks.go
@@ -1,0 +1,216 @@
+package expanders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lawrencegripper/azbrowse/pkg/armclient"
+)
+
+const azureDatabricksTemplateURL string = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}"
+
+// Auth docs: https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token
+
+// This is the Azure AD application ID of the global databricks application
+// this is constant for all tentants/subscriptions as owned by databricks team
+const azureDatabricksGlobalApplicationID string = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
+
+// This is the azure management endpoint used. Would need updating for sovereign clouds etc
+const azureManagementEndpoint string = "https://management.core.windows.net/"
+
+type workspaceResponse struct {
+	Properties struct {
+		WorkspaceURL string `json:"workspaceUrl"`
+	} `json:"properties"`
+}
+
+// AzureDatabricksExpander expands the kubernetes aspects of AKS
+type AzureDatabricksExpander struct {
+	ExpanderBase
+	client *armclient.Client
+}
+
+func (e *AzureDatabricksExpander) setClient(c *armclient.Client) {
+	e.client = c
+}
+
+// Name returns the name of the expander
+func (e *AzureDatabricksExpander) Name() string {
+	return "AzureDatabricksExpander"
+}
+
+// DoesExpand checks if this is a storage account
+func (e *AzureDatabricksExpander) DoesExpand(ctx context.Context, currentItem *TreeNode) (bool, error) {
+	swaggerResourceType := currentItem.SwaggerResourceType
+	if currentItem.ItemType == "resource" && swaggerResourceType != nil {
+		if swaggerResourceType.Endpoint.TemplateURL == azureDatabricksTemplateURL {
+			return true, nil
+		}
+	}
+	if currentItem.Namespace == "AzureDatabricksExpander" {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Expand returns the SwaggerExpander set up for this Databricks workspace
+func (e *AzureDatabricksExpander) Expand(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+
+	swaggerResourceType := currentItem.SwaggerResourceType
+	if currentItem.Namespace != "AzureDatabricksExpander" &&
+		swaggerResourceType != nil &&
+		swaggerResourceType.Endpoint.TemplateURL == azureDatabricksTemplateURL {
+		newItems := []*TreeNode{}
+		newItems = append(newItems, &TreeNode{
+			ID:        currentItem.ID + "/<workspace>",
+			Parentid:  currentItem.ID,
+			Namespace: "AzureDatabricksExpander",
+			Name:      "Connect to Databricks workspace...",
+			Display:   "Connect to Databricks workspace...",
+			ItemType:  SubResourceType,
+			ExpandURL: ExpandURLNotSupported,
+			Metadata: map[string]string{
+				"WorkspaceID":           currentItem.ID,
+				"SuppressSwaggerExpand": "true",
+				"SuppressGenericExpand": "true",
+			},
+		})
+
+		return ExpanderResult{
+			Err:               nil,
+			Response:          ExpanderResponse{Response: ""}, // Swagger expander will supply the response
+			SourceDescription: "AzureDatabricksExpander request",
+			Nodes:             newItems,
+			IsPrimaryResponse: false,
+		}
+	}
+
+	if currentItem.Namespace == "AzureDatabricksExpander" && currentItem.ItemType == SubResourceType {
+		return e.expandWorkspaceRoot(ctx, currentItem)
+	}
+
+	return ExpanderResult{
+		Err:               fmt.Errorf("Error - unhandled Expand"),
+		Response:          ExpanderResponse{Response: "Error!"},
+		SourceDescription: "AzureDatabricksExpander request",
+	}
+}
+
+func (e *AzureDatabricksExpander) expandWorkspaceRoot(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+
+	workspaceID := currentItem.Metadata["WorkspaceID"]
+
+	// Check for existing config for the cluster
+	apiSet := e.getAPISetForWorkspace(workspaceID)
+	var err error
+	if apiSet == nil {
+		apiSet, err = e.createAPISetForWorkspace(ctx, workspaceID)
+		if err != nil {
+			return ExpanderResult{
+				Err:               err,
+				Response:          ExpanderResponse{Response: "Error!"},
+				SourceDescription: "AzureDatabricksExpander request",
+			}
+		}
+		GetSwaggerResourceExpander().AddAPISet(*apiSet)
+	}
+
+	swaggerResourceTypes := apiSet.GetResourceTypes()
+
+	newItems := []*TreeNode{}
+	for _, child := range swaggerResourceTypes {
+		resourceType := child
+		display := resourceType.Display
+		if display == "{}" {
+			display = resourceType.Endpoint.TemplateURL
+		}
+		newItems = append(newItems, &TreeNode{
+			Parentid:            currentItem.ID,
+			ID:                  currentItem.ID + "/" + display,
+			Namespace:           "swagger",
+			Name:                display,
+			Display:             display,
+			ExpandURL:           resourceType.Endpoint.TemplateURL, // all fixed template URLs
+			ItemType:            SubResourceType,
+			SwaggerResourceType: &resourceType,
+			Metadata: map[string]string{
+				"SwaggerAPISetID": currentItem.ID,
+			},
+		})
+	}
+
+	return ExpanderResult{
+		Err:               nil,
+		Response:          ExpanderResponse{Response: ""},
+		SourceDescription: "AzureDatabricksExpander request",
+		Nodes:             newItems,
+		IsPrimaryResponse: true,
+	}
+}
+
+func (e *AzureDatabricksExpander) createAPISetForWorkspace(ctx context.Context, workspaceID string) (*SwaggerAPISetDatabricks, error) {
+
+	managementToken, err := armclient.AcquireTokenForResourceFromAzCLI(azureManagementEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	databricksToken, err := armclient.AcquireTokenForResourceFromAzCLI(azureDatabricksGlobalApplicationID)
+	if err != nil {
+		return nil, err
+	}
+
+	workspaceURL, err := e.getWorkspaceUrl(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	swaggerResourceTypes := e.loadResourceTypes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Register the swagger config so that the swagger expander can take over
+	apiSet := NewSwaggerAPISetDatabricks(swaggerResourceTypes, workspaceID, workspaceID+"/<workspace>", workspaceURL, managementToken.AccessToken, databricksToken.AccessToken)
+	return &apiSet, nil
+}
+func (e *AzureDatabricksExpander) getAPISetForWorkspace(workspaceID string) *SwaggerAPISetDatabricks {
+
+	swaggerAPISet := GetSwaggerResourceExpander().GetAPISet(workspaceID + "/<workspace>")
+	if swaggerAPISet == nil {
+		return nil
+	}
+	apiSet := (*swaggerAPISet).(SwaggerAPISetDatabricks)
+	return &apiSet
+}
+
+func (e *AzureDatabricksExpander) getWorkspaceUrl(ctx context.Context, workspaceID string) (string, error) {
+	data, err := e.client.DoRequest(ctx, "GET", workspaceID+"?api-version=2018-04-01")
+	if err != nil {
+		return "", fmt.Errorf("Failed to get workspace data: " + err.Error() + workspaceID)
+	}
+
+	var response workspaceResponse
+	err = json.Unmarshal([]byte(data), &response)
+	if err != nil {
+		err = fmt.Errorf("Error unmarshalling response: %s\nURL:%s", err, workspaceID)
+		return "", err
+	}
+
+	workspaceURL := response.Properties.WorkspaceURL
+
+	if workspaceURL == "" {
+		return "", fmt.Errorf("Workspace URL lookup failed")
+	}
+
+	return workspaceURL, nil
+}
+
+// Delete attempts to delete the item. Returns true if deleted, false if not handled, an error if an error occurred attempting to delete
+func (e AzureDatabricksExpander) Delete(ctx context.Context, item *TreeNode) (bool, error) {
+	return false, nil
+}
+
+func (e *AzureDatabricksExpander) testCases() (bool, *[]expanderTestCase) {
+	return false, nil
+}

--- a/internal/pkg/expanders/registerExpanders.go
+++ b/internal/pkg/expanders/registerExpanders.go
@@ -70,6 +70,9 @@ func InitializeExpanders(client *armclient.Client) {
 		&AzureSearchServiceExpander{
 			client: client,
 		},
+		&AzureDatabricksExpander{
+			client: client,
+		},
 	}
 }
 

--- a/pkg/armclient/armclient.go
+++ b/pkg/armclient/armclient.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/time/rate"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/lawrencegripper/azbrowse/internal/pkg/errorhandling"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
@@ -50,7 +51,7 @@ const requestPerSecBurst = 5
 // NewClientFromCLI creates a new client using the auth details on disk used by the azurecli
 func NewClientFromCLI(tenantID string, responseProcessors ...ResponseProcessor) *Client {
 	aquireToken := func(clearCache bool) (AzCLIToken, error) {
-		return aquireTokenFromAzCLI(clearCache, tenantID)
+		return acquireTokenFromAzCLI(clearCache, tenantID)
 	}
 	return &Client{
 		responseProcessors: responseProcessors,

--- a/pkg/armclient/authutils.go
+++ b/pkg/armclient/authutils.go
@@ -17,7 +17,7 @@ type AzCLIToken struct {
 
 var currentToken *AzCLIToken
 
-func aquireTokenFromAzCLI(clearCache bool, tenantID string) (AzCLIToken, error) {
+func acquireTokenFromAzCLI(clearCache bool, tenantID string) (AzCLIToken, error) {
 	if currentToken == nil || clearCache {
 		args := []string{"account", "get-access-token", "--output", "json"}
 
@@ -46,4 +46,21 @@ func aquireTokenFromAzCLI(clearCache bool, tenantID string) (AzCLIToken, error) 
 	}
 
 	return *currentToken, nil
+}
+
+// AcquireTokenForResourceFromAzCLI gets a token for the specified resource endpoint
+func AcquireTokenForResourceFromAzCLI(resource string) (AzCLIToken, error) {
+	args := []string{"account", "get-access-token", "--output", "json", "--resource", resource}
+
+	out, err := exec.Command("az", args...).Output()
+	if err != nil {
+		return AzCLIToken{}, fmt.Errorf("%s (try running 'az account get-access-token' to get more details)", err)
+	}
+
+	var r AzCLIToken
+	err = json.Unmarshal(out, &r)
+	if err != nil {
+		return AzCLIToken{}, err
+	}
+	return r, nil
 }

--- a/pkg/swagger/swagger.go
+++ b/pkg/swagger/swagger.go
@@ -187,10 +187,14 @@ func GetPathsFromSwagger(doc *loads.Document, config *Config, pathPrefix string)
 		if err != nil {
 			return []Path{}, err
 		}
-		lastSegment := endpoint.URLSegments[len(endpoint.URLSegments)-1]
-		name := lastSegment.Match
+		segment := endpoint.URLSegments[len(endpoint.URLSegments)-1]
+		name := segment.Match
+		if name == "list" && len(endpoint.URLSegments) > 2 {
+			segment = endpoint.URLSegments[len(endpoint.URLSegments)-2] // 'list' is generic and usually preceded by something more descriptive
+			name = segment.Match
+		}
 		if name == "" {
-			name = "{" + lastSegment.Name + "}"
+			name = "{" + segment.Name + "}"
 		}
 		path := Path{
 			Endpoint:              &endpoint,

--- a/pkg/swagger/swagger.go
+++ b/pkg/swagger/swagger.go
@@ -150,6 +150,18 @@ func addConfigPaths(paths []Path, config *Config) ([]Path, error) {
 				getOperation.Endpoint = &getEndpoint
 			}
 			newPath.Operations.Get = getOperation
+
+			if additionalPath.DeletePath != "" {
+				deleteEndpoint, err := endpoints.GetEndpointInfoFromURL(additionalPath.DeletePath, "")
+				if err != nil {
+					return []Path{}, err
+				}
+				newPath.Operations.Delete = PathOperation{
+					Permitted: true,
+					Endpoint:  &deleteEndpoint,
+				}
+			}
+
 			paths = append(paths, newPath)
 		}
 	}

--- a/pkg/swagger/types.go
+++ b/pkg/swagger/types.go
@@ -146,6 +146,8 @@ type AdditionalPath struct {
 	Path string
 	// GetPath allows the actual path used at runtime to be overridden
 	GetPath string
+	// DeletePath allows a delete url to be specified
+	DeletePath string
 	// FixedContent provides static content to render in place of making an API call
 	FixedContent string
 	// SubPathRegesx holds regex info for modifying subpath URLs


### PR DESCRIPTION
Supports 
* browsing into clusters, jobs, runs, secret scopes, groups, instance-pools and tokens.
* deletion for some resources (resources that support deletion and have a tree node for the individual resource)

Not yet implemented
* workspace, DBFS
* Update of resources