### PR TITLE
Add command to sort list items

### DIFF
--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -216,6 +216,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 	listUpdateCommand := keybindings.NewListUpdateHandler(list, status, ctx, content, g)
 	itemCopyItemIDCommand := keybindings.NewItemCopyItemIDHandler(content, status)
 	listDebugCopyItemDataCommand := keybindings.NewListDebugCopyItemDataHandler(list, status)
+	listSortCommand := keybindings.NewListSortHandler(list)
 
 	commands := []keybindings.Command{
 		commandPanelFilterCommand,
@@ -226,6 +227,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 		listUpdateCommand,
 		itemCopyItemIDCommand,
 		toggleDemoModeCommand,
+		listSortCommand,
 	}
 	if settings.EnableTracing {
 		commands = append(commands, listDebugCopyItemDataCommand)

--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -278,6 +278,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 	keybindings.AddHandler(keybindings.NewListClearFilterHandler(list))
 	keybindings.AddHandler(commandPanelAzureSearchQueryCommand)
 	keybindings.AddHandler(itemCopyItemIDCommand)
+	keybindings.AddHandler(listSortCommand)
 	if settings.EnableTracing {
 		keybindings.AddHandler(listDebugCopyItemDataCommand)
 	}

--- a/internal/pkg/keybindings/keyhandlers.go
+++ b/internal/pkg/keybindings/keyhandlers.go
@@ -43,6 +43,7 @@ const (
 	HandlerIDFilter                  HandlerID = "filter"                //nolint:golint
 	HandlerIDAzureSearchQuery        HandlerID = "azuresearchquery"      //nolist:golint
 	HandlerIDToggleDemoMode          HandlerID = "toggledemomode"        //nolist:golint
+	HandlerIDListSort                HandlerID = "listsort"              //nolint:golint
 )
 
 // KeyHandler is an interface that all key handlers must implement

--- a/internal/pkg/keybindings/listhandlers.go
+++ b/internal/pkg/keybindings/listhandlers.go
@@ -797,3 +797,38 @@ func (h *ListDebugCopyItemDataHandler) Invoke() error {
 }
 
 ////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////
+type ListSortHandler struct {
+	ListHandler
+	List *views.ListWidget
+}
+
+var _ Command = &ListSortHandler{}
+
+func NewListSortHandler(list *views.ListWidget) *ListSortHandler {
+	handler := &ListSortHandler{
+		List: list,
+	}
+	handler.id = HandlerIDListSort
+	return handler
+}
+
+func (h ListSortHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		return h.Invoke()
+	}
+}
+
+func (h *ListSortHandler) DisplayText() string {
+	return "Sort list items"
+}
+func (h *ListSortHandler) IsEnabled() bool {
+	return true
+}
+func (h *ListSortHandler) Invoke() error {
+	h.List.SortItems()
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////

--- a/internal/pkg/views/commandpanel.go
+++ b/internal/pkg/views/commandpanel.go
@@ -268,7 +268,7 @@ func (w *CommandPanelWidget) panelChanged(content string) {
 		triggerLayout = true
 	}
 	if w.options != nil {
-		// apply filter, re-selecting the current item
+		// apply filter, re-selecting the current item (assuming it's still in the list)
 		selectedID := ""
 		if w.selectedIndex >= 0 && w.selectedIndex < len(*w.filteredOptions) {
 			selectedID = (*w.filteredOptions)[w.selectedIndex].ID
@@ -283,6 +283,10 @@ func (w *CommandPanelWidget) panelChanged(content string) {
 				}
 				filterOptions = append(filterOptions, option)
 			}
+		}
+		// if there's just a single item in the list then select it
+		if len(filterOptions) == 1 {
+			w.selectedIndex = 0
 		}
 		w.filteredOptions = &filterOptions
 		triggerLayout = true

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -3,6 +3,7 @@ package views
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
@@ -398,4 +399,18 @@ func (w *ListWidget) MoveDown() {
 func (w *ListWidget) SetShouldRender(val bool) {
 	w.shouldRender = val
 	w.contentView.SetShouldRender(val)
+}
+
+func (w *ListWidget) SortItems() {
+
+	getSortName := func(itemName string) string {
+		return strings.ToLower(itemName)
+	}
+	sortFunc := func(i, j int) bool {
+		iValue := getSortName(w.items[i].Name)
+		jValue := getSortName(w.items[j].Name)
+		return iValue < jValue
+	}
+
+	sort.Slice(w.items, sortFunc)
 }


### PR DESCRIPTION
* Adds a new command to the command palette to sort the items in the list alphabetically by name (case-insensitive sort)
* Doesn't have a default shortcut key, but users can configure a shortcut
* Updates the command palette so that if the filter applied has reduced the list of commands to a single command, it is auto-selected (this allows the following sequence of keys to sort the list `Ctrl+p sort<enter>`