### PR TITLE
Improve startup and autocompletion performance

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,7 +60,7 @@ ENV GO111MODULE=on
 
 # Configure apt, install packages and tools
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog fuse nano xterm \
+    && apt-get -y install --no-install-recommends apt-utils dialog fuse nano xterm locales \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git iproute2 procps lsb-release \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,6 +85,11 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Setup locale as required by snapd: https://stackoverflow.com/questions/28405902/how-to-set-the-locale-inside-a-debian-ubuntu-docker-container
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
 ENV GIT_PROMPT_START='\033[1;36mazb-devcon>\033[0m\033[0;33m\w\a\033[0m'
 
 # Save command line history 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,17 @@ swagger-codegen:
 	# Test the generated code initalizes
 	$(GO_BINARY) test -v internal/pkg/expanders/swagger-armspecs_test.go internal/pkg/expanders/swagger-armspecs.generated.go internal/pkg/expanders/swagger-armspecs.go internal/pkg/expanders/swagger.go internal/pkg/expanders/types.go
 
+## autocomplete-install:
+## 		Add autocompletion for azbrowse to your bash prompt
+autocomplete-install: install
+	echo 'source <(azbrowse completion bash)' >> ~/.bashrc
+	echo "Create a new shell and autocomplete will be working"
+
+## autocomplete-test:
+##		Invoke autocompletion for subscriptions and time the result
+autocomplete-test: install
+	@/bin/bash -c "time azbrowse __complete --subscription LG"
+
 ## test-selfupdate:
 ##		Launches AzBrowse with a low version number to allow testing of the self-update feature
 test-selfupdate: checks

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently I'm using it every day **but it is experimental so use with caution on
 
 # Cool what else can it do?
 
-Lots [check out the guided tour here](docs/getting-started.md). For advanced [config review the settings page here](docs/config.mg).
+Lots [check out the guided tour here](docs/getting-started.md). For advanced [config review the settings page here](docs/config.md).
 
 - Edit/Update resource
 - Multi-resource delete

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently I'm using it every day **but it is experimental so use with caution on
 
 # Cool what else can it do?
 
-Lots [check out the guided tour here](docs/getting-started.md).
+Lots [check out the guided tour here](docs/getting-started.md). For advanced [config review the settings page here](docs/config.mg).
 
 - Edit/Update resource
 - Multi-resource delete

--- a/cmd/azbrowse/cmd.go
+++ b/cmd/azbrowse/cmd.go
@@ -10,12 +10,16 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/lawrencegripper/azbrowse/internal/pkg/config"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/filesystem"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/storage"
 	"github.com/lawrencegripper/azbrowse/internal/pkg/tracing"
 	"github.com/spf13/cobra"
 )
+
+const keyForAccountCache = "accountCache"
 
 func handleCommandAndArgs() {
 
@@ -98,26 +102,52 @@ func createRootCmd() *cobra.Command {
 	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "(optional) specify the tenant id to get an access token for (see az account list -o json)")
 	cmd.Flags().StringVar(&subscription, "subscription", "", "(optional) specify a subscription to load")
 
-	if err := cmd.RegisterFlagCompletionFunc("subscription", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-
-		out, err := exec.Command("az", "account", "list", "--query", "[].[name, id] | [] | sort(@)", "--output", "tsv").Output()
-		if err != nil {
-			return []string{}, cobra.ShellCompDirectiveError
-		}
-
-		reader := bytes.NewReader(out)
-		scanner := bufio.NewScanner(reader)
-		values := []string{}
-		for scanner.Scan() {
-			values = append(values, "\""+strings.ReplaceAll(scanner.Text(), " ", "\\ ")+"\"")
-		}
-
-		return values, cobra.ShellCompDirectiveNoFileComp
-	}); err != nil {
+	if err := cmd.RegisterFlagCompletionFunc("subscription", subscriptionAutocompletion); err != nil {
 		panic(err)
 	}
 
 	return cmd
+}
+
+// This allows azbrowse to update the account cache used for autocompletion
+func updateAccountCache() {
+	out, err := exec.Command("az", "account", "list", "--query", "[].[name, id] | [] | sort(@)", "--output", "tsv").Output()
+	if err != nil {
+		return
+	}
+	err = storage.PutCacheForTTL(keyForAccountCache, string(out))
+	if err != nil {
+		panic("Failed to save account list to cache")
+	}
+}
+
+// Provide support for autocompleting subscriptions
+func subscriptionAutocompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var accountList []byte
+
+	validCache, value, err := storage.GetCacheWithTTL(keyForAccountCache, time.Hour*6)
+	if !validCache || err != nil {
+		out, err := exec.Command("az", "account", "list", "--query", "[].[name, id] | [] | sort(@)", "--output", "tsv").Output()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+		err = storage.PutCacheForTTL(keyForAccountCache, string(out))
+		if err != nil {
+			panic("Failed to save account list to cache")
+		}
+		accountList = out
+	} else {
+		accountList = []byte(value)
+	}
+
+	reader := bytes.NewReader(accountList)
+	scanner := bufio.NewScanner(reader)
+	values := []string{}
+	for scanner.Scan() {
+		values = append(values, "\""+strings.ReplaceAll(scanner.Text(), " ", "\\ ")+"\"")
+	}
+
+	return values, cobra.ShellCompDirectiveNoFileComp
 }
 
 func createVersionCommand() *cobra.Command {

--- a/cmd/azbrowse/cmd.go
+++ b/cmd/azbrowse/cmd.go
@@ -110,7 +110,7 @@ func createRootCmd() *cobra.Command {
 }
 
 // This allows azbrowse to update the account cache used for autocompletion
-// due to it's use in completion func errors are supressed
+// due to it's use in completion func errors are suppressed
 func getAccountListAndUpdateCache() []byte {
 	out, err := exec.Command("az", "account", "list", "--query", "[].[name, id] | [] | sort(@)", "--output", "tsv").Output()
 	if err != nil {

--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -82,7 +82,7 @@ func run(settings *config.Settings) {
 	// Asynconously update the account cache we're holding
 	go func() {
 		defer errorhandling.RecoveryWithCleanup()
-		updateAccountCache()
+		getAccountListAndUpdateCache()
 	}()
 
 	// Configure the gui instance

--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -39,13 +39,14 @@ func main() {
 }
 
 func run(settings *config.Settings) {
-	confirmAndSelfUpdate()
-
+	// Warning: The sequence of calls is important.
 	// Setup the root context and span for open tracing
 	ctx, span := configureTracing(settings)
 
 	// Load the db
 	storage.LoadDB()
+	// Note self update now requires storage loaded first.
+	confirmAndSelfUpdate()
 
 	// Start tracking async responses from ARM
 	responseProcessor, err := views.StartWatchingAsyncARMRequests(ctx)

--- a/docs/config.md
+++ b/docs/config.md
@@ -4,6 +4,15 @@ By default azbrowse looks for configuration in `/root/.azbrowse-settings.json` o
 
 Below is a table containing some of the default key bindings. If you'd like to customise the key bindings to be more suitable for your setup, please refer to the section on [custom key bindings](#custom-key-bindings).
 
+## Updates
+
+Users can set Environment Vars to control how AzBrowse checks for updates. 
+
+| Environment Variable | Does |
+| ---------------------| ---------- |
+| `AZBROWSE_FORCE_UPDATE=anyvaluehere` | Force Azbrowse to check for updates on launch. Normaly would only check every 6 hours |
+| `AZBROWSE_SKIP_UPDATE=anyvaluehere` | Skip Update check |
+
 
 ## Navigation
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,7 +10,7 @@ Users can set Environment Vars to control how AzBrowse checks for updates.
 
 | Environment Variable | Does |
 | ---------------------| ---------- |
-| `AZBROWSE_FORCE_UPDATE=anyvaluehere` | Force Azbrowse to check for updates on launch. Normaly would only check every 6 hours |
+| `AZBROWSE_FORCE_UPDATE=anyvaluehere` | Force Azbrowse to check for updates on launch. Normally would only check every 6 hours |
 | `AZBROWSE_SKIP_UPDATE=anyvaluehere` | Skip Update check |
 
 

--- a/go.mod
+++ b/go.mod
@@ -29,12 +29,14 @@ require (
 	github.com/nsf/termbox-go v0.0.0-20181027232701-60ab7e3d12ed
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
+	github.com/pkg/errors v0.8.1
 	github.com/rhysd/go-github-selfupdate v1.1.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/shurcooL/httpfs v0.0.0-20181222201310-74dc9339e414 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/spf13/cobra v1.0.0
+	github.com/stephanos/clock v0.0.0-20161224195152-e4ec0ab5053e
 	github.com/stretchr/testify v1.3.0
 	github.com/stuartleeks/colorjson v0.0.0-20190711214622-761cbd7eeca6
 	github.com/stuartleeks/gocui v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/stephanos/clock v0.0.0-20161224195152-e4ec0ab5053e h1:PQRvygw1P0KwOMoRQgWZDvEHHr71IrqffNBFx+/zF6g=
+github.com/stephanos/clock v0.0.0-20161224195152-e4ec0ab5053e/go.mod h1:dwToEiNfnifg5gO0zbbjCVMwfOpNQZ9IqmMdhpF94Xw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/pkg/storage/store.go
+++ b/internal/pkg/storage/store.go
@@ -125,7 +125,10 @@ func GetCacheWithTTL(key string, ttl time.Duration) (valid bool, value string, e
 	return true, cacheItem, nil
 }
 
-// PutCacheItemForTTL puts an item in the cache bucket
+// PutCacheItemForTTL puts an item in the cache bucket.
+// *Warning* the current setup DOES NOT cleanup items after their TTL it only provides `GetCacheWithTTL`
+// which allows the user to get the key and highlights if it's past the TTL. TTL is defined by the caller when using `GetCacheWithTTL`.
+// This was used as currently no keys are noisy and require cleanup, future uses could update this to do cleanup.
 func PutCacheForTTL(key, value string) error {
 	// Save the Item
 	err := PutCache(key, value)

--- a/internal/pkg/storage/store.go
+++ b/internal/pkg/storage/store.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 	"log"
 	"os/user"
+	"strconv"
 	"time"
 
 	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+	mockableClock "github.com/stephanos/clock"
 )
 
 var db *bolt.DB
+var clock mockableClock.Clock
+
+const ttlLastUpdatedKey = "LastUpdated"
 
 // CloseDB closes the db
 func CloseDB() {
@@ -28,11 +34,15 @@ func LoadDB() {
 		dbLocation = user.HomeDir + "/.azbrowse.db"
 	}
 
+	initDb(dbLocation, mockableClock.New())
+}
+
+func initDb(location string, inputClock mockableClock.Clock) {
+	clock = inputClock
 	waitingMessageTimer := time.AfterFunc(2*time.Second, func() {
 		fmt.Println("AzBrowse is waiting for access to '~/.azbrowse.db', do you have another instance of azbrowse open?")
 	})
-
-	dbCreate, err := bolt.Open(dbLocation, 0600, nil)
+	dbCreate, err := bolt.Open(location, 0600, nil)
 	waitingMessageTimer.Stop()
 	if err != nil {
 		log.Fatal(err)
@@ -56,7 +66,6 @@ func LoadDB() {
 		log.Fatal(err)
 	}
 	fmt.Println("Loading db complete")
-
 }
 
 // PutCache puts an item in the cache bucket
@@ -81,4 +90,53 @@ func GetCache(key string) (string, error) {
 		return "", fmt.Errorf("Failed to find item: %v", err)
 	}
 	return string(s), nil
+}
+
+// GetCacheIfWithinTTL gets an item from the cache if it's with the TTL duration. To simplify the TTL is provided by the caller
+// the data store just tracks the key and it's last updated value
+func GetCacheWithTTL(key string, ttl time.Duration) (valid bool, value string, err error) {
+	cacheItem, err := GetCache(key)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Empty string isn't a valid cache item
+	if cacheItem == "" {
+		return false, "", err
+	}
+
+	// Get the Last updated time for this cache key
+	cacheItemLastUpdated, err := GetCache(key + ttlLastUpdatedKey)
+	if err != nil || cacheItemLastUpdated == "" {
+		return false, cacheItem, err
+	}
+	lastUpdatedEpoc, err := strconv.ParseInt(cacheItemLastUpdated, 10, 64)
+	if err != nil {
+		return false, cacheItem, errors.Wrapf(err, "Failed to parse %v", cacheItemLastUpdated)
+	}
+
+	// Check if the ttl has expired
+	ttlExpiresAfter := time.Unix(lastUpdatedEpoc, 0).Add(ttl)
+	if clock.Now().After(ttlExpiresAfter) {
+		// It has
+		return false, cacheItem, nil
+	}
+
+	return true, cacheItem, nil
+}
+
+// PutCacheItemForTTL puts an item in the cache bucket
+func PutCacheForTTL(key, value string) error {
+	// Save the Item
+	err := PutCache(key, value)
+	// Track when it was saved
+	errUpdate := PutCache(key+ttlLastUpdatedKey, epocToString())
+	if errUpdate != nil {
+		return errUpdate
+	}
+	return err
+}
+
+func epocToString() string {
+	return strconv.FormatInt(clock.Now().Unix(), 10)
 }

--- a/internal/pkg/storage/store_test.go
+++ b/internal/pkg/storage/store_test.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	mockableClock "github.com/stephanos/clock"
+)
+
+var mockClock = mockableClock.NewMock()
+var testTime = time.Date(2019, 01, 01, 01, 00, 00, 00, time.UTC)
+
+func TestCacheWithTTL(t *testing.T) {
+	// Create a test instance of the DB
+	file, err := ioutil.TempFile(os.TempDir(), "azb-storagetests.db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name()) //nolint: errcheck
+	initDb(file.Name(), mockClock)
+
+	tests := []struct {
+		// Name is used to identify the test, as the cache key and as the cache value
+		// it should be unique in the test set.
+		name           string
+		ttl            time.Duration
+		fastForward    time.Duration
+		putValue       bool
+		wantValid      bool
+		wantValueMatch bool
+		wantErr        bool
+	}{
+		{
+			name:           "InsertRetrieveExpectValid",
+			ttl:            time.Hour,
+			fastForward:    time.Minute * 45,
+			wantValid:      true,
+			wantValueMatch: true,
+			wantErr:        false,
+		},
+		{
+			name:           "InsertRetrieveExpectInvalid",
+			ttl:            time.Hour,
+			fastForward:    time.Hour * 2,
+			wantValid:      false,
+			wantValueMatch: true,
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := PutCacheForTTL(tt.name, tt.name)
+			if err != nil {
+				t.Errorf("PutCacheForTTL errored = %v, want no error", err)
+				return
+			}
+			mockClock.Set(testTime.Add(tt.fastForward))
+
+			gotValid, gotValue, err := GetCacheWithTTL(tt.name, tt.ttl)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCacheWithTTL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotValid != tt.wantValid {
+				t.Errorf("GetCacheWithTTL() gotValid = %v, want %v", gotValid, tt.wantValid)
+			}
+
+			// Note to avoid duplication the tt.name field is set as the value of the cache item too
+			if gotValue != tt.name && tt.wantValueMatch {
+				t.Errorf("GetCacheWithTTL() gotValue = %v, want %v", gotValue, tt.name)
+			}
+		})
+	}
+}
+
+func TestGetCacheWithTTL_withNonexistentKey_ExpectErr(t *testing.T) {
+	// Create a test instance of the DB
+	file, err := ioutil.TempFile(os.TempDir(), "azb-storagetests.db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name()) //nolint: errcheck
+	initDb(file.Name(), mockClock)
+
+	isValid, _, err := GetCacheWithTTL("keydoesntexist", time.Hour)
+
+	if isValid {
+		t.Error("Expect invalid cache result. Got valid")
+	}
+
+	if err != nil {
+		t.Errorf("Expected no error but got err = %+v", err)
+	}
+}


### PR DESCRIPTION
Fixes #248 

- Add environment vars to disable the check or force it
- Tweak devcontainer to fix locale error seen in bash
- Cache the account list from `az` command to improve autocompletion perf