### PR TITLE
Correctly escape spaces in sub names

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -137,3 +137,6 @@ RUN echo "alias go=richgo" >> "/root/.bashrc"
 # Install pip
 COPY get-pip.py /tmp/get-pip.py
 RUN python3 /tmp/get-pip.py
+
+# Install autocompletion for azbrowse
+RUN echo 'source <(azbrowse completion bash)' >> "/root/.bashrc"

--- a/cmd/azbrowse/cmd.go
+++ b/cmd/azbrowse/cmd.go
@@ -313,7 +313,8 @@ func subscriptionAutocompletion(cmd *cobra.Command, args []string, toComplete st
 	}
 	values := make([]string, len(accountList)*2)
 	for _, a := range accountList {
-		values = append(values, a.Name)
+		// Add the name and correctly escape spaces and quote the value
+		values = append(values, "\""+strings.Replace(a.Name, " ", "\\ ", -1)+"\"")
 		values = append(values, a.ID)
 	}
 


### PR DESCRIPTION
Fixes #273 

When autocompeting subs with spaces in their name things now function correctly.