### PR TITLE
Format on SetContent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: swagger-codegen checks test
 ## debug:
 ##		Starts azbrowse using Delve ready for debugging from VSCode.
 debug:
-	dlv debug ./cmd/azbrowse --headless --listen localhost:2345 --api-version 2
+	dlv debug ./cmd/azbrowse --headless --listen localhost:2345 --api-version 2 -- ${ARGS}
 
 ## debug-fuzzer:
 ##		Starts azbrowse using Delve ready for debugging from VSCode and running the fuzzer.


### PR DESCRIPTION
Should improve performance
closes #292 PageDn failing on single line content

There's still room for improvement as the PageDown handling computes the number of lines based on the count of `\n` characters in the content, and doesn't account for line wrapping