### PR TITLE
Push devcontainer on main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,20 @@ jobs:
 
     - name: CI Tooling
       run: sudo apt update && sudo apt install build-essential fuse -y
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     
     - name: Build devcontainer for tooling
       run: sudo -E make devcontainer
+
+    - name: Push devcontainer for caching
+      if: ${{ github.ref == 'refs/heads/main' }}
+      run: sudo -E make devcontainer-push
 
     - name: Build the Docker image, run tests and publish(on master only)
       run: sudo -E make devcontainer-release


### PR DESCRIPTION
- Push updated build of devcontainer on main

This change is aimed at speeding up PR builds by ensuring the devcontainer 
image is pushed and available for the docker cache to use on most builds.
