### PR TITLE
Fix #307: Confirming delete doesn't update UI

### DIFF
--- a/internal/pkg/eventing/eventing.go
+++ b/internal/pkg/eventing/eventing.go
@@ -61,6 +61,8 @@ func (s *StatusEvent) HasExpired() bool {
 
 // Update sends and update to the status event
 func (s *StatusEvent) Update() {
+	// lets assume this should bump the timeout by 5secs
+	s.SetTimeout(time.Second * 5)
 	SendStatusEvent(s)
 }
 

--- a/internal/pkg/views/notifications.go
+++ b/internal/pkg/views/notifications.go
@@ -104,6 +104,8 @@ func (w *NotificationWidget) ConfirmDelete() {
 	// Take a copy of the current pending deletes
 	pending := make([]*expanders.TreeNode, len(w.pendingDeletes))
 	copy(pending, w.pendingDeletes)
+	// Clear the pending deletes list while we delete things
+	w.pendingDeletes = []*expanders.TreeNode{}
 
 	// Force UI to re-render to pickup
 	w.gui.Update(func(g *gocui.Gui) error {
@@ -166,8 +168,6 @@ func (w *NotificationWidget) ConfirmDelete() {
 		event.InProgress = false
 		event.SetTimeout(time.Second * 2)
 		event.Update()
-
-		w.pendingDeletes = []*expanders.TreeNode{}
 	}()
 }
 

--- a/internal/pkg/views/statusbar.go
+++ b/internal/pkg/views/statusbar.go
@@ -68,6 +68,10 @@ func NewStatusbarWidget(x, y, w int, hideGuids bool, g *gocui.Gui) *StatusbarWid
 				// Remove any that have now expired
 				if message.HasExpired() {
 					delete(widget.messages, message.ID())
+					// Removing an item that has expired may result in
+					// an different item being displayed so we track this
+					// so we call g.update correctly
+					changesMade = true
 					continue
 				}
 			}
@@ -130,8 +134,6 @@ func (w *StatusbarWidget) addStatusEvent(eventObj interface{}) {
 		return
 	}
 	w.messages[event.ID()] = event
-	// Favor the most recent message
-	w.currentMessage = event
 }
 
 // Layout draws the widget in the gocui view


### PR DESCRIPTION
Fixes #307

- The status notifications weren't correctly triggering a UI update when processing expired notifications.
- Pending delete list wasn't cleared until after deleting had finished. It is not cleared as delete is started.
