### PR TITLE
Compare Filter using ToLower

### DIFF
--- a/internal/pkg/views/itemview.go
+++ b/internal/pkg/views/itemview.go
@@ -189,8 +189,10 @@ func (w *ItemWidget) SetFilter(filterString string) {
 	// ensure the content isn't under the filter resultbox
 	filteredResult.WriteString("\n\n")
 
+	var filterStringLower = strings.ToLower(filterString)
+
 	for _, line := range currentContent {
-		if strings.Contains(strings.ToLower(line), strings.ToLower(filterString)) {
+		if strings.Contains(strings.ToLower(line), filterStringLower) {
 			line = highlightText(line, filterString)
 			filteredResult.WriteString(line + "\n")
 		}

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -78,7 +78,7 @@ func (w *ListWidget) SetFilter(filterString string) {
 	}
 	filteredItems := []*expanders.TreeNode{}
 	for _, item := range w.currentPage.Items {
-		if strings.Contains(strings.ToLower(item.Display), filterString) {
+		if strings.Contains(strings.ToLower(item.Display), strings.ToLower(filterString)) {
 			filteredItems = append(filteredItems, item)
 		}
 	}

--- a/internal/pkg/views/list.go
+++ b/internal/pkg/views/list.go
@@ -77,8 +77,11 @@ func (w *ListWidget) SetFilter(filterString string) {
 		return
 	}
 	filteredItems := []*expanders.TreeNode{}
+
+	var filterStringLower = strings.ToLower(filterString)
+
 	for _, item := range w.currentPage.Items {
-		if strings.Contains(strings.ToLower(item.Display), strings.ToLower(filterString)) {
+		if strings.Contains(strings.ToLower(item.Display), filterStringLower) {
 			filteredItems = append(filteredItems, item)
 		}
 	}


### PR DESCRIPTION
This makes filtering case insensitive. 

Currently, the items in the list have ToLower applied, but the filter itself doesn't. This results in a filter of `M` not finding anything, my `m` will find items that include both upper and lower case `m` characters.