### PR TITLE
Handle missing codeblock finish in readme

### DIFF
--- a/scripts/swagger_update/api_set.py
+++ b/scripts/swagger_update/api_set.py
@@ -118,10 +118,10 @@ def get_api_version_tag(resource_provider_name, readme_contents, overrides):
 
 code_block_end_regex = re.compile("^[\\s]*```[\\s]*$", flags=re.MULTILINE)
 def find_api_version(resource_provider_name, readme_contents, version_tag, input_file_additions):
-
     # Regex to match:   ```yaml $(tag) == 'the-version-tag`
     # Also match:       ```yaml $(tag) == 'the-version-tag` || $(tag) == 'some-other-tag'
     # But don't match   ```yaml $(tag) == 'the-version-tag' && $(another-condition)
+    print(version_tag)
     start_match = re.search(
         "^```[\\s]*yaml [^&^\\n]*\\$\\(tag\\) == '" + version_tag + "'[^&^\\n]*$",
         readme_contents,
@@ -131,6 +131,9 @@ def find_api_version(resource_provider_name, readme_contents, version_tag, input
         return None
 
     end_match = code_block_end_regex.search(readme_contents, start_match.end())
+    if end_match == None:
+        return None
+        
     yaml_contents = readme_contents[start_match.end() : end_match.start()]
 
     yaml_data = yaml.load(yaml_contents, Loader=yaml.BaseLoader)
@@ -160,6 +163,7 @@ def get_api_version_from_readme(resource_provider_name, readme_path, version_ove
         print("==> no version tag found in readme: " + readme_path)
         return None
 
+    print(readme_path)
     api_version = find_api_version(resource_provider_name, contents, version_tag, input_file_additions)
     return api_version
 

--- a/scripts/swagger_update/api_set.py
+++ b/scripts/swagger_update/api_set.py
@@ -121,7 +121,6 @@ def find_api_version(resource_provider_name, readme_contents, version_tag, input
     # Regex to match:   ```yaml $(tag) == 'the-version-tag`
     # Also match:       ```yaml $(tag) == 'the-version-tag` || $(tag) == 'some-other-tag'
     # But don't match   ```yaml $(tag) == 'the-version-tag' && $(another-condition)
-    print(version_tag)
     start_match = re.search(
         "^```[\\s]*yaml [^&^\\n]*\\$\\(tag\\) == '" + version_tag + "'[^&^\\n]*$",
         readme_contents,
@@ -163,7 +162,6 @@ def get_api_version_from_readme(resource_provider_name, readme_path, version_ove
         print("==> no version tag found in readme: " + readme_path)
         return None
 
-    print(readme_path)
     api_version = find_api_version(resource_provider_name, contents, version_tag, input_file_additions)
     return api_version
 


### PR DESCRIPTION
Marketplace catalog readme has a YAML block with missing end closing block. This makes swagger update handle this by skipping the badly formed version.