### PR TITLE
Add support for viewing container app logs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -98,3 +98,5 @@ RUN \
 
 # Avoid permissions issues when user UID is mapped see: https://github.com/devcontainers/ci/issues/176
 ENV GOPATH="/home/$USERNAME/go"
+# Ensure GOPATH/bin is in the path (so that azbrowse is found after `make install`)
+ENV PATH="/home/$USERNAME/go/bin:$PATH"

--- a/cmd/azbrowse/main.go
+++ b/cmd/azbrowse/main.go
@@ -240,6 +240,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 	toggleDemoModeCommand := keybindings.NewToggleDemoModeHandler(settings, list, status, content)
 
 	commandPanelAzureSearchQueryCommand := keybindings.NewCommandPanelAzureSearchQueryHandler(commandPanel, content, list)
+	commandPanelContainerAppLogsCommand := keybindings.NewCommandPanelContainerAppLogsHandler(commandPanel, content, list)
 
 	listActionsCommand := keybindings.NewListActionsHandler(list, ctx)
 	listOpenCommand := keybindings.NewListOpenHandler(list, ctx)
@@ -253,6 +254,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 		commandPanelFilterCommand,
 		copyCommand,
 		commandPanelAzureSearchQueryCommand,
+		commandPanelContainerAppLogsCommand,
 		listActionsCommand,
 		listOpenCommand,
 		listUpdateCommand,
@@ -308,6 +310,7 @@ func setupViewsAndKeybindings(ctx context.Context, g *gocui.Gui, settings *confi
 	keybindings.AddHandler(keybindings.NewListHomeHandler(list))
 	keybindings.AddHandler(keybindings.NewListClearFilterHandler(list))
 	keybindings.AddHandler(commandPanelAzureSearchQueryCommand)
+	keybindings.AddHandler(commandPanelContainerAppLogsCommand)
 	keybindings.AddHandler(itemCopyItemIDCommand)
 	keybindings.AddHandler(listSortCommand)
 	if settings.EnableTracing {

--- a/cmd/swagger-codegen/main.go
+++ b/cmd/swagger-codegen/main.go
@@ -224,6 +224,11 @@ func getARMConfig() *swagger.Config {
 			"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}/{recordType}/{relativeRecordSetName}": {
 				Path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}/ALL/{recordType}/{relativeRecordSetName}",
 			},
+			// Container Apps
+			"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/revisionsApi/revisions/": {
+				Name: "detectorProperties",
+				Path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/revisionsApi/revisions", // Path unchanged
+			},
 		},
 	}
 	return config

--- a/internal/pkg/expanders/containerApp.go
+++ b/internal/pkg/expanders/containerApp.go
@@ -235,26 +235,6 @@ func (e *ContainerAppExpander) GetAuthToken(ctx context.Context, currentItem *Tr
 	return authTokenResponse.Properties.Token, nil
 }
 
-// func (e *ContainerAppExpander) getLogs(ctx context.Context, logStreamEndpoint string, authToken string) (string, error) {
-// 	// TODO - actually get the logs!
-
-// 	request, err := http.NewRequestWithContext(ctx, "GET", logStreamEndpoint, nil)
-// 	if err != nil {
-// 		return "", fmt.Errorf("failed to create request: %s", err)
-// 	}
-// 	request.Header.Set("Authorization", "Bearer "+authToken)
-
-// 	httpClient := http.DefaultClient
-
-// 	response, err := httpClient.Do(request)
-// 	if err != nil {
-// 		return "", fmt.Errorf("failed to make request: %s", err)
-// 	}
-
-// 	defer response.Body.Close() //nolint: errcheck
-
-// }
-
 type ContainerAppReplicaContainer struct {
 	ContainerID         string `json:"containerId"`
 	ExecEndpoint        string `json:"execEndpoint"`

--- a/internal/pkg/expanders/containerApp.go
+++ b/internal/pkg/expanders/containerApp.go
@@ -1,0 +1,286 @@
+package expanders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lawrencegripper/azbrowse/internal/pkg/interfaces"
+	"github.com/lawrencegripper/azbrowse/pkg/armclient"
+	"github.com/lawrencegripper/azbrowse/pkg/endpoints"
+)
+
+const containerAppRevisionReplicaTemplate = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/replicas/{replicaName}"
+
+// ContainerAppNodeType is used to indicate the type of ContainerApp node
+type ContainerAppNodeType string
+
+const (
+	ContainerAppNode_RevisionReplicaContainers = "containerApp.revision.replica.containers"
+	ContainerAppNode_RevisionReplicaContainer  = "containerApp.revision.replica.container"
+)
+
+var _ Expander = &ContainerAppExpander{}
+
+type ContainerAppExpanderInterface interface {
+	GetAuthToken(ctx context.Context, currentItem *TreeNode) (string, error)
+}
+
+var _ ContainerAppExpanderInterface = &ContainerAppExpander{}
+
+type ContainerAppExpander struct {
+	ExpanderBase
+	client *armclient.Client
+}
+
+func (e *ContainerAppExpander) setClient(c *armclient.Client) {
+	e.client = c
+}
+
+// Name returns the name of the expander
+func (e *ContainerAppExpander) Name() string {
+	return "ContainerAppExpander"
+}
+
+// DoesExpand checks if we can expand this node
+func (e *ContainerAppExpander) DoesExpand(ctx context.Context, currentItem *TreeNode) (bool, error) {
+	swaggerResourceType := currentItem.SwaggerResourceType
+	if currentItem.ItemType == "subResource" && swaggerResourceType != nil {
+		if swaggerResourceType.Endpoint.TemplateURL == containerAppRevisionReplicaTemplate {
+			return true, nil
+		}
+	}
+	if currentItem.ExpandReturnType == ContainerAppNode_RevisionReplicaContainers {
+		return true, nil
+	}
+	if currentItem.ExpandReturnType == ContainerAppNode_RevisionReplicaContainer {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Expand returns items in the container app
+func (e *ContainerAppExpander) Expand(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+	swaggerResourceType := currentItem.SwaggerResourceType
+	if swaggerResourceType != nil && swaggerResourceType.Endpoint.TemplateURL == containerAppRevisionReplicaTemplate {
+		return e.expandReplica(ctx, currentItem)
+	}
+	if currentItem.ExpandReturnType == ContainerAppNode_RevisionReplicaContainers {
+		return e.expandReplicaContainers(ctx, currentItem)
+	}
+	if currentItem.ExpandReturnType == ContainerAppNode_RevisionReplicaContainer {
+		return e.expandReplicaContainer(ctx, currentItem)
+	}
+
+	return ExpanderResult{
+		Err:               fmt.Errorf("Error - unhandled Expand"),
+		Response:          ExpanderResponse{Response: "Error!"},
+		SourceDescription: "ContainerAppExpander request",
+	}
+}
+
+func (e *ContainerAppExpander) expandReplica(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+
+	swaggerResourceType := currentItem.SwaggerResourceType
+	matchResult := swaggerResourceType.Endpoint.Match(currentItem.ID)
+	if !matchResult.IsMatch {
+		return ExpanderResult{
+			Err:               fmt.Errorf("Error - failed to match own resource type URL"),
+			Response:          ExpanderResponse{Response: "Error!"},
+			SourceDescription: "ContainerAppExpander request",
+		}
+	}
+
+	newItems := []*TreeNode{}
+	newItems = append(newItems, &TreeNode{
+		Name:                  "Containers",
+		Display:               "containers",
+		ID:                    currentItem.ID + "/containers",
+		Parentid:              currentItem.ID,
+		ExpandReturnType:      ContainerAppNode_RevisionReplicaContainers,
+		SubscriptionID:        currentItem.SubscriptionID,
+		SuppressSwaggerExpand: true,
+		SuppressGenericExpand: true,
+		Metadata: map[string]string{
+			"ReplicaExpandURL":  currentItem.ExpandURL,
+			"subscriptionId":    matchResult.Values["subscriptionId"],
+			"resourceGroupName": matchResult.Values["resourceGroupName"],
+			"containerAppName":  matchResult.Values["containerAppName"],
+			"revisionName":      matchResult.Values["revisionName"],
+			"replicaName":       matchResult.Values["replicaName"],
+		},
+	})
+
+	return ExpanderResult{
+		IsPrimaryResponse: false,
+		Nodes:             newItems,
+		Response:          ExpanderResponse{Response: "TODO - add content here"},
+		SourceDescription: "ContainerAppExpander request",
+	}
+}
+
+func (e *ContainerAppExpander) expandReplicaContainers(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+
+	replicaExpandURL := currentItem.Metadata["ReplicaExpandURL"]
+	data, err := e.client.DoRequest(ctx, "GET", replicaExpandURL)
+	if err != nil {
+		return ExpanderResult{
+			Err:               err,
+			Response:          ExpanderResponse{Response: ""},
+			SourceDescription: "ContainerAppExpander list",
+			IsPrimaryResponse: false,
+		}
+	}
+
+	var replica ContainerAppReplicaResponse
+	err = json.Unmarshal([]byte(data), &replica)
+	if err != nil {
+		return ExpanderResult{
+			Err:               fmt.Errorf("Error parsing replica JSON: %s", err),
+			IsPrimaryResponse: false,
+			SourceDescription: "ContainerAppExpander request",
+		}
+	}
+
+	containersDisplay, err := json.Marshal(replica.Properties.Containers)
+	if err != nil {
+		return ExpanderResult{
+			Err:               fmt.Errorf("Error serializing containers JSON: %s", err),
+			IsPrimaryResponse: false,
+			SourceDescription: "ContainerAppExpander request",
+		}
+	}
+	_ = containersDisplay
+
+	newItems := []*TreeNode{}
+	for _, container := range replica.Properties.Containers {
+		newItems = append(newItems, &TreeNode{
+			Name:                  "Replica container: " + container.Name,
+			Display:               container.Name,
+			ID:                    currentItem.ID + "/" + container.Name,
+			Parentid:              currentItem.ID,
+			ExpandReturnType:      ContainerAppNode_RevisionReplicaContainer,
+			SubscriptionID:        currentItem.SubscriptionID,
+			SuppressSwaggerExpand: true,
+			SuppressGenericExpand: true,
+			Metadata: map[string]string{
+				"ContainerAppNodeType": "containerApp.revision.replica.container",
+				"ReplicaExpandURL":     currentItem.ExpandURL,
+				"LogStreamEndpoint":    container.LogStreamEndpoint,
+				"subscriptionId":       currentItem.Metadata["subscriptionId"],
+				"resourceGroupName":    currentItem.Metadata["resourceGroupName"],
+				"containerAppName":     currentItem.Metadata["containerAppName"],
+				"revisionName":         currentItem.Metadata["revisionName"],
+				"replicaName":          currentItem.Metadata["replicaName"],
+			},
+		})
+	}
+	return ExpanderResult{
+		IsPrimaryResponse: true,
+		Nodes:             newItems,
+		Response:          ExpanderResponse{Response: string(containersDisplay), ResponseType: interfaces.ResponseJSON},
+		SourceDescription: "ContainerAppExpander request",
+	}
+}
+func (e *ContainerAppExpander) expandReplicaContainer(ctx context.Context, currentItem *TreeNode) ExpanderResult {
+	return ExpanderResult{
+		IsPrimaryResponse: true,
+		Nodes:             []*TreeNode{},
+		Response:          ExpanderResponse{Response: "Use the command panel to show container logs", ResponseType: interfaces.ResponsePlainText},
+		SourceDescription: "ContainerAppExpander request",
+	}
+}
+
+// GetAuthToken retrieves the authentication token for the container app specifiec in currentItem
+func (e *ContainerAppExpander) GetAuthToken(ctx context.Context, currentItem *TreeNode) (string, error) {
+	var containerAppNode *TreeNode
+
+	// Walk up the tree looking for the container app node
+	for node := currentItem; node != nil; node = node.Parent {
+		if node.SwaggerResourceType != nil && node.SwaggerResourceType.Endpoint.TemplateURL == "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}" {
+			containerAppNode = node
+			break
+		}
+	}
+	if containerAppNode == nil {
+		return "", fmt.Errorf("failed to find container app node")
+	}
+
+	containerAppEndpoint := containerAppNode.SwaggerResourceType.Endpoint
+	authEndpoint, err := endpoints.GetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/getAuthToken", containerAppEndpoint.APIVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to get auth endpoint: %s", err)
+	}
+
+	match := containerAppEndpoint.Match(containerAppNode.ExpandURL)
+	if !match.IsMatch {
+		return "", fmt.Errorf("failed to match container app URL")
+	}
+
+	authURL, err := authEndpoint.BuildURL(match.Values)
+	if err != nil {
+		return "", fmt.Errorf("failed to build auth URL: %s", err)
+	}
+
+	data, err := e.client.DoRequest(ctx, "POST", authURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to get auth token: %s", err)
+	}
+
+	var authTokenResponse ContainerAppAuthTokenResponse
+	err = json.Unmarshal([]byte(data), &authTokenResponse)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse auth token response: %s", err)
+	}
+	return authTokenResponse.Properties.Token, nil
+}
+
+// func (e *ContainerAppExpander) getLogs(ctx context.Context, logStreamEndpoint string, authToken string) (string, error) {
+// 	// TODO - actually get the logs!
+
+// 	request, err := http.NewRequestWithContext(ctx, "GET", logStreamEndpoint, nil)
+// 	if err != nil {
+// 		return "", fmt.Errorf("failed to create request: %s", err)
+// 	}
+// 	request.Header.Set("Authorization", "Bearer "+authToken)
+
+// 	httpClient := http.DefaultClient
+
+// 	response, err := httpClient.Do(request)
+// 	if err != nil {
+// 		return "", fmt.Errorf("failed to make request: %s", err)
+// 	}
+
+// 	defer response.Body.Close() //nolint: errcheck
+
+// }
+
+type ContainerAppReplicaContainer struct {
+	ContainerID         string `json:"containerId"`
+	ExecEndpoint        string `json:"execEndpoint"`
+	LogStreamEndpoint   string `json:"logStreamEndpoint"`
+	Name                string `json:"name"`
+	Ready               bool   `json:"ready"`
+	RestartCount        int    `json:"restartCount"`
+	RunningState        string `json:"runningState"`
+	RunningStateDetails string `json:"runningStateDetails"`
+	Started             bool   `json:"started"`
+}
+
+type ContainerAppReplicaResponse struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Properties struct {
+		Containers []ContainerAppReplicaContainer `json:"containers"`
+		// CreatedTime         string                         `json:"createdTime"`
+		RunningState string `json:"runningState"`
+		// RunningStateDetails string                         `json:"runningStateDetails"`
+	} `json:"properties"`
+}
+
+type ContainerAppAuthTokenResponse struct {
+	Properties struct {
+		Token   string `json:"token"`
+		Expires string `json:"expires"`
+	} `json:"properties"`
+}

--- a/internal/pkg/expanders/registerExpanders.go
+++ b/internal/pkg/expanders/registerExpanders.go
@@ -85,6 +85,9 @@ func InitializeExpanders(client *armclient.Client, graphClient *armclient.Client
 		&DiagnosticSettingsExpander{
 			client: client,
 		},
+		&ContainerAppExpander{
+			client: client,
+		},
 	}
 }
 

--- a/internal/pkg/expanders/swagger-armspecs.generated.go
+++ b/internal/pkg/expanders/swagger-armspecs.generated.go
@@ -1366,8 +1366,8 @@ func (e *SwaggerAPISetARMResources) loadResourceTypes() []swagger.ResourceType {
 								}},
 						},
 						{
-							Display:  "revisions",
-							Endpoint: endpoints.MustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/revisionsApi/revisions", "2024-03-01"),
+							Display:  "detectorProperties",
+							Endpoint: endpoints.MustGetEndpointInfoFromURL("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/revisionsApi/revisions/", "2024-03-01"),
 							SubResources: []swagger.ResourceType{
 								{
 									Display:  "{revisionName}",

--- a/internal/pkg/keybindings/keyhandlers.go
+++ b/internal/pkg/keybindings/keyhandlers.go
@@ -45,6 +45,7 @@ const (
 	HandlerIDAzureSearchQuery        HandlerID = "azuresearchquery"      //nolist:golint
 	HandlerIDToggleDemoMode          HandlerID = "toggledemomode"        //nolist:golint
 	HandlerIDListSort                HandlerID = "listsort"              //nolint:golint
+	HandlerIDContainerAppLogs        HandlerID = "containerapplogs"      //nolist:golint
 )
 
 // KeyHandler is an interface that all key handlers must implement

--- a/internal/pkg/keybindings/list_containerapp_logs.go
+++ b/internal/pkg/keybindings/list_containerapp_logs.go
@@ -92,8 +92,6 @@ func (h *CommandPanelContainerAppLogsHandler) Invoke() error {
 }
 
 func (h *CommandPanelContainerAppLogsHandler) getLogs(ctx context.Context, logStreamEndpoint string, authToken string) error {
-	// TODO - actually get the logs!
-
 	url, err := url.Parse(logStreamEndpoint)
 	if err != nil {
 		return fmt.Errorf("failed to parse log stream endpoint: %s", err)

--- a/internal/pkg/keybindings/list_containerapp_logs.go
+++ b/internal/pkg/keybindings/list_containerapp_logs.go
@@ -1,0 +1,134 @@
+package keybindings
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/awesome-gocui/gocui"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/eventing"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/expanders"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/interfaces"
+	"github.com/lawrencegripper/azbrowse/internal/pkg/views"
+)
+
+type CommandPanelContainerAppLogsHandler struct {
+	ListHandler
+	commandPanelWidget *views.CommandPanelWidget
+	list               *views.ListWidget
+	content            *views.ItemWidget
+}
+
+var _ Command = &CommandPanelContainerAppLogsHandler{}
+
+func NewCommandPanelContainerAppLogsHandler(commandPanelWidget *views.CommandPanelWidget, content *views.ItemWidget, list *views.ListWidget) *CommandPanelContainerAppLogsHandler {
+	handler := &CommandPanelContainerAppLogsHandler{
+		commandPanelWidget: commandPanelWidget,
+		content:            content,
+		list:               list,
+	}
+	handler.id = HandlerIDContainerAppLogs
+
+	return handler
+}
+
+func (h *CommandPanelContainerAppLogsHandler) Fn() func(g *gocui.Gui, v *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		if h.IsEnabled() {
+			return h.Invoke()
+		}
+		return nil
+	}
+}
+
+func (h *CommandPanelContainerAppLogsHandler) DisplayText() string {
+	return "Container Apps: Show logs"
+}
+
+func (h *CommandPanelContainerAppLogsHandler) IsEnabled() bool {
+	currentItem := h.list.CurrentItem()
+	if currentItem != nil && currentItem.Metadata["ContainerAppNodeType"] == expanders.ContainerAppNode_RevisionReplicaContainer {
+		return true
+	}
+	return false
+}
+
+func (h *CommandPanelContainerAppLogsHandler) Invoke() error {
+
+	currentItem := h.list.CurrentItem()
+	logStreamEndpoint := currentItem.Metadata["LogStreamEndpoint"]
+	if logStreamEndpoint == "" {
+		return fmt.Errorf("no log stream endpoint found")
+	}
+
+	containerAppExpander, ok := (currentItem.Expander).(expanders.ContainerAppExpanderInterface)
+	if !ok {
+		return fmt.Errorf("current item is not a ContainerAppExpanderInterface")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	authToken, err := containerAppExpander.GetAuthToken(ctx, currentItem)
+	if err != nil {
+		cancel()
+		return fmt.Errorf("failed to get auth token: %s", err)
+	}
+
+	_ = authToken
+
+	go func() {
+		// Wait for the user to navigate away
+		navigatedChannel := eventing.SubscribeToTopic("list.navigated")
+		<-navigatedChannel
+		// Clean up subscription
+		eventing.Unsubscribe(navigatedChannel)
+		// Cancel log context
+		cancel()
+	}()
+
+	return h.getLogs(ctx, logStreamEndpoint, authToken)
+
+}
+
+func (h *CommandPanelContainerAppLogsHandler) getLogs(ctx context.Context, logStreamEndpoint string, authToken string) error {
+	// TODO - actually get the logs!
+
+	url, err := url.Parse(logStreamEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to parse log stream endpoint: %s", err)
+	}
+	query := url.Query()
+	query.Add("output", "text")
+	query.Add("follow", "true")
+	query.Add("taillines", "50")
+	url.RawQuery = query.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %s", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+authToken)
+
+	httpClient := http.DefaultClient
+
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %s", err)
+	}
+
+	scanner := bufio.NewScanner(response.Body)
+	go func() {
+		defer response.Body.Close() //nolint: errcheck
+
+		content := ""
+		for scanner.Scan() {
+			content += scanner.Text() + "\n"
+			h.content.SetContent(content, interfaces.ResponsePlainText, "Logs")
+		}
+
+		content += "!!Connection closed"
+		h.content.SetContent(content, interfaces.ResponsePlainText, "Logs")
+	}()
+	return nil
+}

--- a/pkg/swagger/swagger.go
+++ b/pkg/swagger/swagger.go
@@ -200,13 +200,16 @@ func GetPathsFromSwagger(doc *loads.Document, config *Config, pathPrefix string)
 			return []Path{}, err
 		}
 		segment := endpoint.URLSegments[len(endpoint.URLSegments)-1]
-		name := segment.Match
-		if name == "list" && len(endpoint.URLSegments) > 2 {
-			segment = endpoint.URLSegments[len(endpoint.URLSegments)-2] // 'list' is generic and usually preceded by something more descriptive
-			name = segment.Match
-		}
+		name := override.Name
 		if name == "" {
-			name = "{" + segment.Name + "}"
+			name = segment.Match
+			if name == "list" && len(endpoint.URLSegments) > 2 {
+				segment = endpoint.URLSegments[len(endpoint.URLSegments)-2] // 'list' is generic and usually preceded by something more descriptive
+				name = segment.Match
+			}
+			if name == "" {
+				name = "{" + segment.Name + "}"
+			}
 		}
 		path := Path{
 			Endpoint:              &endpoint,

--- a/pkg/swagger/types.go
+++ b/pkg/swagger/types.go
@@ -136,6 +136,7 @@ type PathOverride struct {
 	RewritePath bool   // rewrite the path in generated code. Only advised to address case issues or inconsistent match segment names
 	PutPath     string // Force the PUT endpoint to be output or override it
 	DeletePath  string // Force the PUT endpoint to be output or override it
+	Name        string // If set to non-empty value this overrides the endpoint Name from swagger
 }
 
 // AdditionalPath provides metadata for additional paths to inject into the generated hierarchy


### PR DESCRIPTION
Add support for viewing container app logs
- support drilling into the containers under a revision's replica
- add command to view logs for a container
- support streaming logs and cancel context to terminate log request when user navigates away from the log view

Also updates the dev container to include `GOPATH/bin` in the `PATH` so that `azbrowse` is found in the release script after running `make install`
