### PR TITLE
Update docker-api gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,10 +5,10 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     colorize (1.1.0)
-    docker-api (2.2.0)
-      excon (>= 0.47.0)
+    docker-api (2.3.0)
+      excon (>= 0.64.0)
       multi_json
-    excon (0.99.0)
+    excon (0.111.0)
     git (1.19.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
@@ -62,4 +62,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.4.7
+   2.4.22

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -6,7 +6,7 @@ gemfile do
   source 'https://rubygems.org'
   gem 'git', '=1.8.1'
   gem 'colorize', '=0.8.1'
-  gem 'docker-api', '=2.1.0'
+  gem 'docker-api', '=2.3.0'
 end
 
 require 'colorize'


### PR DESCRIPTION
I've bumped the version of the `docker-api` gem as per [this issue](https://github.com/upserve/docker-api/issues/586) and that seems to addresses the [CI failure](https://github.com/lawrencegripper/azbrowse/actions/runs/10150688701/job/28068348472?pr=579#step:5:1013)