### PR TITLE
chore: go v1.24 update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/lawrencegripper/azbrowse/snapbase:latest as builder
 
 # Multi-stage build, only need the snaps from the builder. Copy them one at a
 # time so they can be cached.
-FROM golang:1.20-bullseye
+FROM golang:1.24-bullseye
 LABEL org.opencontainers.image.source https://github.com/lawrencegripper/azbrowse
 
 COPY --from=builder /snap/core /snap/core

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lawrencegripper/azbrowse
 
-go 1.20
+go 1.24
 
 require (
 	github.com/101loops/bdd v0.0.0-20161224202746-3e71f58e2cc3 // indirect


### PR DESCRIPTION
Update from go 1.20 to go 1.24 to support newest dependabot PRs